### PR TITLE
Refactor /records to /trips, fix persistence, and resolve UI constraints

### DIFF
--- a/src/components/LineSelector.jsx
+++ b/src/components/LineSelector.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import { X, Map as MapIcon, Train, Building2 } from 'lucide-react';
 
 export const LineSelector = ({ isOpen, onClose, onSelect, railwayData, allowedLines }) => {
@@ -61,7 +62,7 @@ export const LineSelector = ({ isOpen, onClose, onSelect, railwayData, allowedLi
     if (!isOpen) return null;
     const currentRegionData = groups[activeTab];
 
-    return (
+    return createPortal(
         <div className="fixed inset-0 z-[600] bg-black/50 flex items-center justify-center p-4 animate-fade-in pointer-events-auto" onClick={onClose}>
             <div className="bg-white w-full max-w-2xl max-h-[85vh] h-[85vh] rounded-3xl shadow-2xl flex flex-col overflow-hidden animate-slide-up ring-1 ring-black/5" onClick={e => e.stopPropagation()}>
                 <div className="p-4 border-b bg-gray-50 flex justify-between items-center shrink-0">
@@ -116,6 +117,7 @@ export const LineSelector = ({ isOpen, onClose, onSelect, railwayData, allowedLi
                     )}
                 </div>
             </div>
-        </div>
+        </div>,
+        document.body
     );
 };

--- a/src/components/LoginModal.jsx
+++ b/src/components/LoginModal.jsx
@@ -253,7 +253,7 @@ export const LoginModal = ({ isOpen, onClose, onLoginSuccess, user }) => {
   };
 
   return (
-    <div className="fixed inset-0 z-[1000] bg-black/50 flex items-center justify-center p-4 animate-fade-in" onClick={onClose}>
+    <div className="fixed inset-0 z-[1000] bg-black/50 flex items-center justify-center p-4 animate-fade-in pointer-events-auto" onClick={onClose}>
       <div className="bg-white w-full max-w-5xl rounded-2xl shadow-2xl flex flex-col md:flex-row overflow-auto animate-slide-up h-[85vh] md:h-[650px]" onClick={e => e.stopPropagation()}>
 
         {/* Left: Login Form */}

--- a/src/components/Tutorial.jsx
+++ b/src/components/Tutorial.jsx
@@ -15,12 +15,12 @@ const STEPS = [
     },
     {
         id: 'tab-records',
-        target: 'nav a[href="/records"]', // Selector for Records Tab
+        target: 'nav a[href="/trips"]', // Selector for Trips Tab
         title: "行程记录",
         content: "这个标签页是你的旅程控制中心. 你可以在这里查看、添加和管理所有的铁路旅行记录, 或者添加到收藏",
         position: 'top',
         action: 'switch-tab',
-        path: '/records'
+        path: '/trips'
     },
     {
         id: 'add-trip',

--- a/src/globalContext.jsx
+++ b/src/globalContext.jsx
@@ -184,6 +184,7 @@ export const GlobalProvider = ({ children }) => {
         } catch (e) {
             console.error("Save failed", e);
             alert("同步失败: " + e.message);
+            throw e;
         }
     }, [user, trips, pins, folders, badgeSettings, versionInfo]);
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -6,7 +6,7 @@ import './index.css';
 
 import { GlobalProvider } from './globalContext';
 import MainLayout from './MainLayout';
-import RecordsPage from './pages/RecordsPage';
+import TripsPage from './pages/TripsPage';
 import StatsPage from './pages/StatsPage';
 import LoginPage from './pages/LoginPage';
 import TripEditorPage from './pages/TripEditorPage';
@@ -21,15 +21,15 @@ const router = createBrowserRouter([
     children: [
       {
         index: true,
-        element: <Navigate to="/records" replace />
+        element: <Navigate to="/trips" replace />
       },
       {
         path: "map",
         element: null // Map is always rendered in Layout, this route just enables interaction
       },
       {
-        path: "records",
-        element: <RecordsPage />
+        path: "trips",
+        element: <TripsPage />
       },
       {
         path: "stats",
@@ -56,7 +56,7 @@ const router = createBrowserRouter([
         element: <FolderManagerModal />
       },
       {
-        path: "records/folder/:tripId",
+        path: "trips/folder/:tripId",
         element: <AddToFolderModal />
       }
     ]

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -29,35 +29,24 @@ const router = createBrowserRouter([
       },
       {
         path: "trips",
-        element: <TripsPage />
+        element: <TripsPage />,
+        children: [
+            { path: "new", element: <TripEditorPage /> },
+            { path: ":id/edit", element: <TripEditorPage /> },
+            { path: "folder/:tripId", element: <AddToFolderModal /> }
+        ]
       },
       {
         path: "stats",
-        element: <StatsPage />
+        element: <StatsPage />,
+        children: [
+            { path: "card", element: <GithubCardModal /> },
+            { path: "folders", element: <FolderManagerModal /> }
+        ]
       },
       {
         path: "login",
         element: <LoginPage />
-      },
-      {
-        path: "trips/new",
-        element: <TripEditorPage />
-      },
-      {
-        path: "trips/:id/edit",
-        element: <TripEditorPage />
-      },
-      {
-        path: "stats/card",
-        element: <GithubCardModal />
-      },
-      {
-        path: "stats/folders",
-        element: <FolderManagerModal />
-      },
-      {
-        path: "trips/folder/:tripId",
-        element: <AddToFolderModal />
       }
     ]
   }

--- a/src/mainLayout.jsx
+++ b/src/mainLayout.jsx
@@ -303,7 +303,7 @@ export default function MainLayout() {
 
        {/* Navigation Bar (z-30) */}
        <nav className="absolute bottom-0 left-0 right-0 bg-white border-t p-2 flex justify-around shrink-0 pb-safe z-30 pointer-events-auto">
-            <NavLink id="tab-btn-records" to="/records" className={({isActive}) => `p-2 rounded-lg ${isActive ? 'text-emerald-600 bg-emerald-50' : 'text-slate-400'}`}>
+            <NavLink id="tab-btn-trips" to="/trips" className={({isActive}) => `p-2 rounded-lg ${isActive ? 'text-emerald-600 bg-emerald-50' : 'text-slate-400'}`}>
                 <Layers />
             </NavLink>
             <NavLink id="tab-btn-map" to="/map" className={({isActive}) => `p-2 rounded-lg ${isActive ? 'text-emerald-600 bg-emerald-50' : 'text-slate-400'}`}>

--- a/src/pages/StatsPage.jsx
+++ b/src/pages/StatsPage.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useAuth, useUserData, useGeo } from '../globalContext';
 import { api } from '../services/api';
 import { Github, Folder, TrendingUp, Move, Eye, EyeOff, Loader2, Lock, X } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Outlet } from 'react-router-dom';
 import { VersionBadge } from '../components/VersionBadge';
 
 // Helper to calc stats using worker
@@ -136,6 +136,7 @@ export default function StatsPage() {
              <br/>
              <div><span display="inline">更多详情, 参见</span><button display="inline" onClick={() => navigate('/login')} className="text-xs text-blue-400 hover:text-blue-500 hover:underline transition-all items-center gap-1">用户指南</button>
         </div></div>
+        <Outlet />
       </div>
     );
 }

--- a/src/pages/TripEditorPage.jsx
+++ b/src/pages/TripEditorPage.jsx
@@ -31,7 +31,7 @@ export default function TripEditorPage() {
                 setForm(JSON.parse(JSON.stringify(t)));
                 setIsEditing(true);
             } else {
-                navigate('/records'); // Not found
+                navigate('/trips'); // Not found
             }
         } else {
             // New Trip
@@ -47,7 +47,7 @@ export default function TripEditorPage() {
 
     const onClose = () => navigate(-1);
 
-    const onSave = () => {
+    const onSave = async () => {
         const validSegments = form.segments.filter(s => s.fromId !== s.toId);
         if (validSegments.length === 0) { alert("至少包含一段有效行程"); return; }
         if (validSegments.some(s => !s.lineKey || !s.fromId || !s.toId)) { alert("请完善信息"); return; }
@@ -81,8 +81,12 @@ export default function TripEditorPage() {
         if (isEditing && id) { nextTrips = nextTrips.filter(t => t.id.toString() !== id); }
         const finalTrips = [...newTripsToAdd, ...nextTrips].sort((a,b) => b.date.localeCompare(a.date));
 
-        saveData(finalTrips, null, null, null);
-        onClose();
+        try {
+            await saveData(finalTrips, null, null, null);
+            onClose();
+        } catch (e) {
+            // Error is alerted in saveData
+        }
     };
 
     const handleAutoSearch = () => {

--- a/src/pages/TripsPage.jsx
+++ b/src/pages/TripsPage.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useAuth, useUserData, useGeo } from '../globalContext';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Outlet } from 'react-router-dom';
 import { Train, Star, Edit2, Trash2 } from 'lucide-react';
 import { DropZone } from '../components/DragContext';
 import { RouteSlice } from '../components/RouteSlice';
@@ -86,6 +86,7 @@ export default function TripsPage() {
             }}>
                 <button id="btn-add-trip" onClick={() => onAdd()} className="w-full py-4 border-2 border-dashed border-gray-300 text-gray-400 rounded-xl hover:bg-gray-50 font-bold transition">+ 记录新行程</button>
             </DropZone>
+            <Outlet />
         </div>
     );
 }

--- a/src/pages/TripsPage.jsx
+++ b/src/pages/TripsPage.jsx
@@ -5,7 +5,7 @@ import { Train, Star, Edit2, Trash2 } from 'lucide-react';
 import { DropZone } from '../components/DragContext';
 import { RouteSlice } from '../components/RouteSlice';
 
-export default function RecordsPage() {
+export default function TripsPage() {
     const { trips, setTrips, saveData, folders, setFolders } = useUserData();
     const { user } = useAuth();
     const { railwayData } = useGeo();
@@ -36,7 +36,7 @@ export default function RecordsPage() {
         // Or keep it as a local modal since it's small?
         // User said "UI popup control... directly native Router".
         // Let's use a sub-route: /records/folder/:tripId
-        navigate(`/records/folder/${trip.id}`);
+        navigate(`/trips/folder/${trip.id}`);
     };
 
     return (


### PR DESCRIPTION
This PR addresses 4 user requests:
1.  Renames the `/records` route to `/trips` for better semantics. This involved renaming `RecordsPage.jsx` to `TripsPage.jsx` and updating all references in `main.jsx`, `mainLayout.jsx`, `TripEditorPage.jsx`, and `Tutorial.jsx`.
2.  Fixes trip persistence. `TripEditorPage.jsx` now awaits the `saveData` function, which has been updated in `globalContext.jsx` to throw errors so they can be caught and handled. This prevents the editor from closing if the save fails and ensures the save completes before navigation.
3.  Fixes the Route Selection Panel (LineSelector) being clipped. The `LineSelector` component now uses `createPortal` to render into `document.body`, bypassing the `overflow: hidden` constraint of the `TripEditorPage` modal.
4.  Fixes the Login Modal being unclickable. `LoginModal.jsx` now has `pointer-events-auto` on its container to override the `pointer-events-none` set by `MainLayout` on the route outlet.

---
*PR created automatically by Jules for task [11476324448632047062](https://jules.google.com/task/11476324448632047062) started by @OsakaLOOP*