### PR TITLE
Fix infinite loop in Zustand store subscriptions

### DIFF
--- a/src/AppLayout.tsx
+++ b/src/AppLayout.tsx
@@ -23,6 +23,7 @@ import { sliceGeoJsonPath, calculateLatestStats } from './utils/stats';
 import * as turf from '@turf/turf';
 import { meta } from '../public/changelog.json';
 import { api } from './services/api';
+import { useShallow } from 'zustand/react/shallow';
 
 const CURRENT_VERSION = meta["currentVersion"];
 
@@ -31,7 +32,7 @@ export const AppLayout: React.FC = () => {
         activeTab, user, setModalState, setCompanyDB, setRailwayData, setGeoData,
         trips, pins, railwayData, geoData, companyDB, setTrips, setPins, folders, badgeSettings,
         setSegmentGeometries, setTripSegmentsGeometry, segmentGeometries
-    } = useStore(state => ({
+    } = useStore(useShallow(state => ({
         activeTab: state.activeTab,
         user: state.user,
         setModalState: state.setModalState,
@@ -50,7 +51,7 @@ export const AppLayout: React.FC = () => {
         setSegmentGeometries: state.setSegmentGeometries,
         setTripSegmentsGeometry: state.setTripSegmentsGeometry,
         segmentGeometries: state.segmentGeometries
-    }));
+    })));
 
     const [stationMenu, setStationMenu] = useState<any>(null);
     const [isExportingKML, setIsExportingKML] = useState(false);

--- a/src/components/layout/BottomNav.tsx
+++ b/src/components/layout/BottomNav.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { Layers, Map as MapIcon, PieChart } from 'lucide-react';
 import { useStore } from '../../store';
+import { useShallow } from 'zustand/react/shallow';
 
 export const BottomNav: React.FC = () => {
-    const { activeTab, setActiveTab } = useStore(state => ({
+    const { activeTab, setActiveTab } = useStore(useShallow(state => ({
         activeTab: state.activeTab,
         setActiveTab: state.setActiveTab
-    }));
+    })));
 
     return (
         <nav className="bg-white border-t p-2 flex justify-around shrink-0 pb-safe z-30">

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -3,6 +3,7 @@ import { Train, LogOut, User, Download, Upload, Building2, FilePlus } from 'luci
 import { useStore } from '../../store';
 import { VersionBadge } from '../VersionBadge';
 import { meta } from '../../../public/changelog.json';
+import { useShallow } from 'zustand/react/shallow';
 
 const CURRENT_VERSION = meta["currentVersion"];
 
@@ -13,7 +14,7 @@ export const Header: React.FC<{
     handleCompanyUpload: (e: any) => void;
     handleFileUpload: (e: any) => void;
 }> = ({ handleExportKML, handleExportUserData, handleImportUserData, handleCompanyUpload, handleFileUpload }) => {
-    const { user, activeTab } = useStore(state => ({ user: state.user, activeTab: state.activeTab }));
+    const { user, activeTab } = useStore(useShallow(state => ({ user: state.user, activeTab: state.activeTab })));
     const setModalState = useStore(state => state.setModalState);
     const logout = useStore(state => state.logout);
 

--- a/src/components/map/FabButton.tsx
+++ b/src/components/map/FabButton.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
 import { Magnet, MapPin } from 'lucide-react';
 import { useStore, PinMode } from '../../store';
+import { useShallow } from 'zustand/react/shallow';
 
 export const FabButton: React.FC = () => {
-    const { activeTab, pinMode, editingPin, setPinMode, setEditingPin } = useStore(state => ({
+    const { activeTab, pinMode, editingPin, setPinMode, setEditingPin } = useStore(useShallow(state => ({
         activeTab: state.activeTab,
         pinMode: state.pinMode,
         editingPin: state.editingPin,
         setPinMode: state.setPinMode,
         setEditingPin: state.setEditingPin
-    }));
+    })));
 
     const togglePinMode = () => {
         if (pinMode === PinMode.Idle) {

--- a/src/components/map/MapContainer.tsx
+++ b/src/components/map/MapContainer.tsx
@@ -4,6 +4,7 @@ import 'leaflet/dist/leaflet.css';
 import { useStore, PinMode, StationMenuData, CustomFeatureCollection, CustomGeoJSONFeature } from '../../store';
 import { findNearestPointOnLine } from '../../utils/railwayRouting';
 import { syncLeafletLayerGroup } from '../../utils/leafletSync';
+import { useShallow } from 'zustand/react/shallow';
 
 interface Props {
     setStationMenu: (menu: StationMenuData | null) => void;
@@ -23,7 +24,7 @@ export const MapContainer: React.FC<Props> = ({ setStationMenu, isDraggingRef })
         geoData, leafletReady, tripSegmentsGeometry, activeTab, mapZoom,
         setMapZoom, setLeafletReady, pins, editingPin, pinMode, railwayData,
         setEditingPin, setPinMode
-    } = useStore(state => ({
+    } = useStore(useShallow(state => ({
         geoData: state.geoData,
         leafletReady: state.leafletReady,
         tripSegmentsGeometry: state.tripSegmentsGeometry,
@@ -37,7 +38,7 @@ export const MapContainer: React.FC<Props> = ({ setStationMenu, isDraggingRef })
         railwayData: state.railwayData,
         setEditingPin: state.setEditingPin,
         setPinMode: state.setPinMode
-    }));
+    })));
 
     useEffect(() => {
         setLeafletReady(true);

--- a/src/components/map/PinEditor.tsx
+++ b/src/components/map/PinEditor.tsx
@@ -1,15 +1,16 @@
 import React, { useEffect } from 'react';
 import { Move, Magnet, Camera, MessageSquare, Trash2, X } from 'lucide-react';
 import { useStore, PinMode } from '../../store';
+import { useShallow } from 'zustand/react/shallow';
 
 const COLOR_PALETTE = ['#ef4444', '#f97316', '#eab308', '#22c55e', '#3b82f6', '#a855f7', '#ec4899', '#64748b'];
 
 export const PinEditor: React.FC = () => {
-    const { editingPin, pinMode, pins } = useStore(state => ({
+    const { editingPin, pinMode, pins } = useStore(useShallow(state => ({
         editingPin: state.editingPin,
         pinMode: state.pinMode,
         pins: state.pins
-    }));
+    })));
     const setEditingPin = useStore(state => state.setEditingPin);
     const setPinMode = useStore(state => state.setPinMode);
     const setPins = useStore(state => state.setPins);

--- a/src/components/modals/AddToFolderModal.tsx
+++ b/src/components/modals/AddToFolderModal.tsx
@@ -1,13 +1,14 @@
 import React, { useEffect } from 'react';
 import { X, Star, CheckCircle2 } from 'lucide-react';
 import { useStore } from '../../store';
+import { useShallow } from 'zustand/react/shallow';
 
 export const AddToFolderModal: React.FC = () => {
-    const { isOpen, trip, folders } = useStore(state => ({
+    const { isOpen, trip, folders } = useStore(useShallow(state => ({
         isOpen: state.modals.addToFolderModalOpen,
         trip: state.modals.currentTripForFolder,
         folders: state.folders
-    }));
+    })));
     const setModalState = useStore(state => state.setModalState);
     const setFolders = useStore(state => state.setFolders);
 

--- a/src/components/modals/FolderManagerModal.tsx
+++ b/src/components/modals/FolderManagerModal.tsx
@@ -1,12 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import { X, Folder, Globe, Trash2 } from 'lucide-react';
 import { useStore } from '../../store';
+import { useShallow } from 'zustand/react/shallow';
 
 export const FolderManagerModal: React.FC = () => {
-    const { isOpen, folders } = useStore(state => ({
+    const { isOpen, folders } = useStore(useShallow(state => ({
         isOpen: state.modals.folderManagerOpen,
         folders: state.folders
-    }));
+    })));
     const setModalState = useStore(state => state.setModalState);
     const setFolders = useStore(state => state.setFolders);
     const [newFolderName, setNewFolderName] = useState("");

--- a/src/components/modals/GithubCardModal.tsx
+++ b/src/components/modals/GithubCardModal.tsx
@@ -2,19 +2,20 @@ import React, { useState, useEffect } from 'react';
 import { X, Github, Eye, EyeOff, Lock, Loader2 } from 'lucide-react';
 import { useStore } from '../../store';
 import { api } from '../../services/api';
+import { useShallow } from 'zustand/react/shallow';
 
 export const GithubCardModal: React.FC = () => {
-    const { isOpen, user, folders, badgeSettings } = useStore(state => ({
+    const { isOpen, user, folders, badgeSettings } = useStore(useShallow(state => ({
         isOpen: !!state.modals.cardModalUser,
         user: state.modals.cardModalUser,
         folders: state.folders,
         badgeSettings: state.badgeSettings
-    }));
+    })));
     const setModalState = useStore(state => state.setModalState);
     const setBadgeSettings = useStore(state => state.setBadgeSettings);
 
     // We need to sync settings back to API, which requires trips, pins
-    const { trips, pins } = useStore(state => ({ trips: state.trips, pins: state.pins }));
+    const { trips, pins } = useStore(useShallow(state => ({ trips: state.trips, pins: state.pins })));
 
     const [cardKey, setCardKey] = useState<string | null>(null);
     const [loading, setLoading] = useState(false);

--- a/src/components/modals/GithubRegisterModal.tsx
+++ b/src/components/modals/GithubRegisterModal.tsx
@@ -2,12 +2,13 @@ import React, { useState, useEffect } from 'react';
 import { X, Github, AlertTriangle, Loader2 } from 'lucide-react';
 import { useStore } from '../../store';
 import { api } from '../../services/api';
+import { useShallow } from 'zustand/react/shallow';
 
 export const GithubRegisterModal: React.FC = () => {
-    const { isOpen, regToken } = useStore(state => ({
+    const { isOpen, regToken } = useStore(useShallow(state => ({
         isOpen: state.modals.isGithubRegOpen,
         regToken: state.modals.githubRegToken
-    }));
+    })));
     const setModalState = useStore(state => state.setModalState);
     const login = useStore(state => state.login);
 

--- a/src/components/modals/TripEditor.tsx
+++ b/src/components/modals/TripEditor.tsx
@@ -4,11 +4,12 @@ import { useStore, EditorMode } from '../../store';
 import { DropZone } from '../DragContext';
 import { LineSelector } from './LineSelector';
 import { isCompanyCompatible, getTransferableLines, findRoute } from '../../utils/railwayRouting'; // Will need to ensure these are typed
+import { useShallow } from 'zustand/react/shallow';
 
 export const TripEditor: React.FC = () => {
     const {
         isOpen, isEditing, form, editorMode, autoForm, isRouteSearching, railwayData, trips, pins, folders, badgeSettings, user
-    } = useStore(state => ({
+    } = useStore(useShallow(state => ({
         isOpen: state.isTripEditing,
         isEditing: !!state.editingTripId,
         form: state.tripForm,
@@ -21,7 +22,7 @@ export const TripEditor: React.FC = () => {
         folders: state.folders,
         badgeSettings: state.badgeSettings,
         user: state.user
-    }));
+    })));
 
     const setForm = useStore(state => state.setTripForm);
     const setEditorMode = useStore(state => state.setEditorMode);

--- a/src/pages/StatsPage.tsx
+++ b/src/pages/StatsPage.tsx
@@ -3,11 +3,12 @@ import { Github, Folder, TrendingUp, Move } from 'lucide-react';
 import { useStore } from '../store';
 import { calcDist } from '../utils/stats';
 import * as turf from '@turf/turf';
+import { useShallow } from 'zustand/react/shallow';
 
 export const StatsPage: React.FC = () => {
     const {
         trips, railwayData, geoData, user, userProfile, segmentGeometries, companyDB
-    } = useStore(state => ({
+    } = useStore(useShallow(state => ({
         trips: state.trips,
         railwayData: state.railwayData,
         geoData: state.geoData,
@@ -15,7 +16,7 @@ export const StatsPage: React.FC = () => {
         userProfile: state.userProfile,
         segmentGeometries: state.segmentGeometries,
         companyDB: state.companyDB
-    }));
+    })));
     const setModalState = useStore(state => state.setModalState);
 
     const { totalTrips, uniqueLines, totalDist, totalCost, rankedSegments } = useMemo(() => {

--- a/src/pages/TripsPage.tsx
+++ b/src/pages/TripsPage.tsx
@@ -4,13 +4,14 @@ import { useStore } from '../store';
 import { DropZone } from '../components/DragContext';
 import { getRouteVisualData } from '../utils/stats';
 import { isMobile } from 'react-device-detect';
+import { useShallow } from 'zustand/react/shallow';
 
 const RouteSlice: React.FC<{ segments: any[] }> = ({ segments }) => {
-    const { segmentGeometries, railwayData, geoData } = useStore(state => ({
+    const { segmentGeometries, railwayData, geoData } = useStore(useShallow(state => ({
         segmentGeometries: state.segmentGeometries,
         railwayData: state.railwayData,
         geoData: state.geoData
-    }));
+    })));
 
     const containerRef = useRef<HTMLDivElement>(null);
     const [containerWidth, setContainerWidth] = useState(0);
@@ -52,7 +53,7 @@ const RouteSlice: React.FC<{ segments: any[] }> = ({ segments }) => {
 };
 
 export const TripsPage: React.FC = () => {
-    const { trips, railwayData } = useStore(state => ({ trips: state.trips, railwayData: state.railwayData }));
+    const { trips, railwayData } = useStore(useShallow(state => ({ trips: state.trips, railwayData: state.railwayData })));
     const setModalState = useStore(state => state.setModalState);
     const startEditingTrip = useStore(state => state.startEditingTrip);
     const removeTrip = useStore(state => state.removeTrip);


### PR DESCRIPTION
This PR fixes the React infinite rendering issue (`Maximum update depth exceeded`) caused by `zustand`'s `useStore` when returning an object. It adds the `useShallow` wrapper from `zustand/react/shallow` across 14 components to ensure object destructuring does not trigger unnecessary updates due to new object references being created on every state change.

---
*PR created automatically by Jules for task [2788241144191123805](https://jules.google.com/task/2788241144191123805) started by @OsakaLOOP*