### PR TITLE
Fix map trajectory rendering

### DIFF
--- a/src/AppLayout.tsx
+++ b/src/AppLayout.tsx
@@ -19,8 +19,8 @@ import { StatsPage } from './pages/StatsPage';
 import { useStore } from './store';
 import { db } from './utils/db';
 import buildKMLString from './buildKml';
-import { sliceGeoJsonPath, calculateLatestStats } from './utils/stats';
-import * as turf from '@turf/turf';
+import { calculateLatestStats } from './utils/stats';
+import GeoWorker from './workers/geo.worker.js?worker';
 import { meta } from '../public/changelog.json';
 import { api } from './services/api';
 import { useShallow } from 'zustand/react/shallow';
@@ -56,6 +56,45 @@ export const AppLayout: React.FC = () => {
     const [stationMenu, setStationMenu] = useState<any>(null);
     const [isExportingKML, setIsExportingKML] = useState(false);
     const isDraggingRef = useRef(false);
+    const workerRef = useRef<Worker | null>(null);
+
+    // --- Worker Setup ---
+    useEffect(() => {
+        workerRef.current = new GeoWorker();
+        return () => {
+            if (workerRef.current) {
+                workerRef.current.terminate();
+            }
+        };
+    }, []);
+
+    const callWorker = (type: string, payload: any): Promise<any> => {
+        return new Promise((resolve, reject) => {
+            if (!workerRef.current) return reject("Worker not initialized");
+            const id = Date.now() + Math.random().toString();
+
+            const handleMessage = (e: MessageEvent) => {
+                if (e.data.id === id) {
+                    workerRef.current?.removeEventListener('message', handleMessage);
+                    if (e.data.type === `${type}_SUCCESS`) {
+                        resolve(e.data.payload);
+                    } else if (e.data.type === 'ERROR') {
+                        reject(new Error(e.data.payload));
+                    }
+                }
+            };
+
+            workerRef.current.addEventListener('message', handleMessage);
+            workerRef.current.postMessage({ id, type, payload });
+        });
+    };
+
+    // --- Sync Data to Worker ---
+    useEffect(() => {
+        if (workerRef.current) {
+            callWorker('SYNC_DATA', { railwayData, geoData }).catch(console.error);
+        }
+    }, [railwayData, geoData]);
 
     // --- 1. Utilities for Parsing and Matching ---
     const normalizeCompanyName = (s: any) => {
@@ -209,19 +248,18 @@ export const AppLayout: React.FC = () => {
             const validResults = results.filter(r => r !== null);
             if (validResults.length > 0) processGeoJsonBatch(validResults, currentCompanyData);
 
+            console.log('[Autoload] 初始化全部完成，应用就绪。');
         } catch (err) { console.error('[Autoload] 致命错误:', err); }
     };
 
-    // --- 3. Geo Calculation Effects (Moved from RailRound) ---
+    // --- 3. Geo Calculation Effects ---
     useEffect(() => {
-        const allSegments = trips.flatMap(t => t.segments || []);
-        const needed = allSegments.filter(seg => {
-            if (!seg.lineKey || !seg.fromId || !seg.toId) return false;
-            return !segmentGeometries.has(`${seg.lineKey}_${seg.fromId}_${seg.toId}`);
-        });
+        // 使用 setTimeout 加上简单的防抖，防止编辑/添加行程时高频触发导致卡顿
+        const timerId = setTimeout(() => {
+            const allSegments = trips.flatMap(t => t.segments || []);
 
-        if (needed.length === 0) {
-            const geometryList = allSegments.map(seg => {
+            // 1. 优先使用已有的缓存进行渲染，保证部分路线立即显示，防止整张地图因为几段缺失而瘫痪。
+            const renderList = allSegments.map(seg => {
                 const key = `${seg.lineKey}_${seg.fromId}_${seg.toId}`;
                 const cached = segmentGeometries.get(key);
                 const line = railwayData[seg.lineKey];
@@ -230,69 +268,69 @@ export const AppLayout: React.FC = () => {
                 if (cached) return { id: seg.id || key, popup: `${seg.lineKey}: ${s1?.name_ja || seg.fromId} → ${s2?.name_ja || seg.toId}`, ...cached };
                 return null;
             }).filter(Boolean);
-            setTripSegmentsGeometry(geometryList);
-            return;
-        }
 
-        const fetchMissing = async () => {
-            const newCache = new Map(segmentGeometries);
-            let updated = false;
+            setTripSegmentsGeometry(renderList);
 
-            for (const seg of needed) {
-                const key = `${seg.lineKey}_${seg.fromId}_${seg.toId}`;
-                let data = await db.get(db.STORE_SEGMENTS, key).catch(() => null);
+            // 2. 筛选缺失的数据发送给 Worker
+            const needed = allSegments.filter(seg => {
+                if (!seg.lineKey || !seg.fromId || !seg.toId) return false;
+                return !segmentGeometries.has(`${seg.lineKey}_${seg.fromId}_${seg.toId}`);
+            });
 
-                if (!data) {
-                    if (!geoData || !geoData.features) continue;
-                    const line = railwayData[seg.lineKey];
-                    if (!line) continue;
-                    const s1 = line.stations.find(s => s.id === seg.fromId);
-                    const s2 = line.stations.find(s => s.id === seg.toId);
-                    if (!s1 || !s2) continue;
+            if (needed.length === 0) return;
 
-                    const parts = seg.lineKey.split(':');
-                    const company = parts[0];
-                    const lineName = parts.slice(1).join(':');
+            const fetchMissing = async () => {
+                const newCache = new Map(segmentGeometries);
+                let updated = false;
+                const toCalculateInWorker: any[] = [];
 
-                    const feature = geoData.features.find((f: any) => f.properties.type === 'line' && f.properties.name === lineName && f.properties.company === company);
+                // 先尝试从 IndexedDB 加载
+                for (const seg of needed) {
+                    const key = `${seg.lineKey}_${seg.fromId}_${seg.toId}`;
+                    let data = await db.get(db.STORE_SEGMENTS, key).catch(() => null);
 
-                    let coords = null; let color = '#38bdf8'; let isMulti = false; let fallback = false;
-
-                    if (feature) {
-                        color = feature.properties.stroke || '#38bdf8';
-                        const latLngs = sliceGeoJsonPath(feature, s1.lat, s1.lng, s2.lat, s2.lng);
-                        if (latLngs) {
-                            coords = latLngs;
-                            if (Array.isArray(latLngs[0]) && Array.isArray(latLngs[0][0])) isMulti = true;
-                        }
+                    if (data) {
+                        newCache.set(key, data);
+                        updated = true;
+                    } else {
+                        toCalculateInWorker.push(seg);
                     }
-
-                    if (!coords) {
-                         fallback = true;
-                         const routeCoords = [];
-                         const startIdx = line.stations.findIndex(st => st.id === seg.fromId);
-                         const endIdx = line.stations.findIndex(st => st.id === seg.toId);
-                         if (startIdx !== -1 && endIdx !== -1) {
-                             const step = startIdx <= endIdx ? 1 : -1;
-                             for (let i = startIdx; i !== endIdx + step; i += step) {
-                                if (i >= 0 && i < line.stations.length) routeCoords.push([line.stations[i].lat, line.stations[i].lng]);
-                             }
-                             if (routeCoords.length > 1) { coords = routeCoords; fallback = false; }
-                         }
-                    }
-                    if (!coords) { coords = [[s1.lat, s1.lng], [s2.lat, s2.lng]]; fallback = true; }
-
-                    data = { coords, color, isMulti, fallback };
-                    await db.set(db.STORE_SEGMENTS, key, data);
                 }
 
-                if (data) { newCache.set(key, data); updated = true; }
-            }
+                // 如果有 IndexedDB 中也没有的，交给 Worker 计算
+                if (toCalculateInWorker.length > 0 && workerRef.current) {
+                    try {
+                        const results = await callWorker('GET_ALL_GEOMETRIES', { segments: toCalculateInWorker });
+                        for (const res of results) {
+                            const { key, data } = res;
+                            if (data) {
+                                newCache.set(key, data);
+                                await db.set(db.STORE_SEGMENTS, key, data);
+                                updated = true;
+                            } else {
+                                // 为了防止无限重试，存一个 Fallback 占位。同样缓存到 IDB。
+                                const fallbackData = { coords: [[0, 0], [0, 0]], color: '#ff0000', isMulti: false, fallback: true };
+                                newCache.set(key, fallbackData);
+                                await db.set(db.STORE_SEGMENTS, key, fallbackData);
+                                updated = true;
+                            }
+                        }
+                    } catch (e) {
+                        console.error("Worker Geo Calc failed:", e);
+                    }
+                }
 
-            if (updated) setSegmentGeometries(newCache);
-        };
+                if (updated) {
+                    setSegmentGeometries(newCache);
+                    // 这里不要调用 setTripSegmentsGeometry，
+                    // 因为 updated 的 segmentGeometries 作为依赖项会触发下一次 useEffect 执行。
+                }
+            };
 
-        fetchMissing();
+            fetchMissing();
+        }, 300); // 300ms 延时/防抖
+
+        return () => clearTimeout(timerId);
     }, [trips, geoData, railwayData, segmentGeometries]);
 
     useEffect(() => { autoLoadData(); }, []);
@@ -303,30 +341,27 @@ export const AppLayout: React.FC = () => {
         setIsExportingKML(true);
         setTimeout(async () => {
             try {
-                if (trips.length === 0 || !geoData || !turf) { alert("无行程记录或地图数据未加载。"); setIsExportingKML(false); return; }
+                if (trips.length === 0 || !geoData) { alert("无行程记录或地图数据未加载。"); setIsExportingKML(false); return; }
                 const allPaths: any[] = [];
+
+                // 由于 sliceGeoJsonPath 已移至 Worker，我们需要用另一种方式处理 KML 导出。
+                // 最简单的方法是重用现有的 segmentGeometries 缓存！
                 trips.forEach(t => {
                     const tripName = `${t.date} - Trip ${t.id}`;
                     t.segments.forEach((seg: any, segIndex: number) => {
-                        const line = railwayData[seg.lineKey];
-                        if (!line) return;
-                        const s1 = line.stations.find(s => s.id === seg.fromId);
-                        const s2 = line.stations.find(s => s.id === seg.toId);
-                        if (!s1 || !s2) return;
-                        const parts = seg.lineKey.split(':');
-                        const company = parts[0];
-                        const lineName = parts.slice(1).join(':');
-                        const feature = geoData.features.find((f: any) => f.properties.type === 'line' && f.properties.name === lineName && f.properties.company === company);
-                        if (feature) {
-                            const coords = sliceGeoJsonPath(feature, s1.lat, s1.lng, s2.lat, s2.lng);
-                            if (coords) {
-                                const kmlCoords = Array.isArray(coords[0]) && Array.isArray(coords[0][0]) ? coords.flat().map((p: any) => `${p[1]},${p[0]},0`).join(' ') : coords.map((p: any) => `${p[1]},${p[0]},0`).join(' ');
-                                allPaths.push({ name: `${tripName} Segment ${segIndex + 1}`, coordinates: kmlCoords, lineKey: seg.lineKey });
-                            }
+                        const key = `${seg.lineKey}_${seg.fromId}_${seg.toId}`;
+                        const cached = segmentGeometries.get(key);
+                        if (cached && cached.coords) {
+                            const coords = cached.coords;
+                            const kmlCoords = cached.isMulti
+                                ? coords.flat().map((p: any) => `${p[1]},${p[0]},0`).join(' ')
+                                : coords.map((p: any) => `${p[1]},${p[0]},0`).join(' ');
+                            allPaths.push({ name: `${tripName} Segment ${segIndex + 1}`, coordinates: kmlCoords, lineKey: seg.lineKey });
                         }
                     });
                 });
-                if (allPaths.length === 0) { alert("未找到可导出路径。"); setIsExportingKML(false); return; }
+
+                if (allPaths.length === 0) { alert("未找到可导出路径（请确保路线在地图上已显示）。"); setIsExportingKML(false); return; }
                 const kmlString = buildKMLString(allPaths);
                 const blob = new Blob([kmlString], { type: 'application/vnd.google-earth.kml+xml' });
                 const url = URL.createObjectURL(blob);

--- a/src/workers/geo.worker.js
+++ b/src/workers/geo.worker.js
@@ -1,5 +1,253 @@
-//几何计算逻辑（calcDist, sliceGeoJsonPath）迁移至 Worker。
+import * as turf from '@turf/turf';
 
-//Worker 内部必须维护 railwayData 和 geoData 的内存副本。
+// 内存数据副本
+let railwayData = {};
+let geoData = { type: 'FeatureCollection', features: [] };
 
-//主线程与 Worker 通信必须使用 Promise 包装的 request/response 模式（带 id 标识）。
+// 辅助：计算两点间直线距离 (Haversine Formula)
+export const calcDist = (lat1, lon1, lat2, lon2) => {
+  if (!lat1 || !lon1 || !lat2 || !lon2) return 0;
+  const R = 6371; // 地球半径 km
+  const dLat = (lat2 - lat1) * Math.PI / 180;
+  const dLon = (lon2 - lon1) * Math.PI / 180;
+  const a = Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+            Math.cos(lat1 * Math.PI / 180) * Math.cos(lat2 * Math.PI / 180) * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return R * c;
+};
+
+// 路径缝合算法: 将乱序的 MultiLineString 缝合成连续的 LineString
+export const stitchRoutes = (turf, multiCoords, startPt) => {
+  let pool = multiCoords.map((coords, i) => {
+    if (!coords || coords.length < 2) return null;
+    return {
+      id: i,
+      coords: coords,
+      head: turf.point(coords[0]),
+      tail: turf.point(coords[coords.length - 1])
+    };
+  }).filter(Boolean);
+
+  if (pool.length === 0) return [];
+  if (pool.length === 1) return pool[0].coords;
+
+  let seedIdx = -1;
+  let minSeedDist = Infinity;
+
+  pool.forEach((seg, i) => {
+    const line = turf.lineString(seg.coords);
+    const dist = turf.pointToLineDistance(startPt, line);
+    if (dist < minSeedDist) { minSeedDist = dist; seedIdx = i; }
+  });
+
+  if (seedIdx === -1) seedIdx = 0;
+
+  let pathSegments = [pool[seedIdx]];
+  pool.splice(seedIdx, 1);
+
+  while (pool.length > 0) {
+    const currentHeadCoords = pathSegments[0].coords;
+    const currentTailCoords = pathSegments[pathSegments.length - 1].coords;
+
+    const pathHeadPt = turf.point(currentHeadCoords[0]);
+    const pathTailPt = turf.point(currentTailCoords[currentTailCoords.length - 1]);
+
+    let bestMatchIdx = -1;
+    let minDist = Infinity;
+    let matchType = '';
+
+    for (let i = 0; i < pool.length; i++) {
+      const seg = pool[i];
+      const d_Tail_Start = turf.distance(pathTailPt, seg.head);
+      const d_Tail_End   = turf.distance(pathTailPt, seg.tail);
+      const d_Head_End   = turf.distance(pathHeadPt, seg.tail);
+      const d_Head_Start = turf.distance(pathHeadPt, seg.head);
+
+      if (d_Tail_Start < minDist) { minDist = d_Tail_Start; bestMatchIdx = i; matchType = 'tail-start'; }
+      if (d_Tail_End < minDist)   { minDist = d_Tail_End;   bestMatchIdx = i; matchType = 'tail-end'; }
+      if (d_Head_End < minDist)   { minDist = d_Head_End;   bestMatchIdx = i; matchType = 'head-end'; }
+      if (d_Head_Start < minDist) { minDist = d_Head_Start; bestMatchIdx = i; matchType = 'head-start'; }
+    }
+
+    if (bestMatchIdx !== -1) {
+      const seg = pool[bestMatchIdx];
+      if (matchType === 'tail-start') {
+        pathSegments.push(seg);
+      } else if (matchType === 'tail-end') {
+        seg.coords.reverse();
+        const temp = seg.head; seg.head = seg.tail; seg.tail = temp;
+        pathSegments.push(seg);
+      } else if (matchType === 'head-end') {
+        pathSegments.unshift(seg);
+      } else if (matchType === 'head-start') {
+        seg.coords.reverse();
+        const temp = seg.head; seg.head = seg.tail; seg.tail = temp;
+        pathSegments.unshift(seg);
+      }
+      pool.splice(bestMatchIdx, 1);
+    } else {
+      break;
+    }
+  }
+
+  let flatCoords = [];
+  pathSegments.forEach(seg => {
+    flatCoords.push(...seg.coords);
+  });
+  return flatCoords;
+};
+
+// [Turf.js] 轨迹切分算法
+export const sliceGeoJsonPath = (feature, startLat, startLng, endLat, endLng) => {
+    if (!turf || !feature || !feature.geometry) return null;
+
+    try {
+      let line = feature;
+      const startPt = turf.point([startLng, startLat]);
+      const endPt = turf.point([endLng, endLat]);
+
+      // If MultiLineString, attempt to stitch segments into a sensible continuous path
+      if (feature.geometry.type === 'MultiLineString') {
+         const multiCoords = feature.geometry.coordinates;
+         const stitchedCoords = stitchRoutes(turf, multiCoords, startPt);
+         if (stitchedCoords && stitchedCoords.length > 0) {
+           line = turf.lineString(stitchedCoords);
+         } else {
+           const flatCoords = feature.geometry.coordinates.flat();
+           line = turf.lineString(flatCoords);
+         }
+      }
+
+      // 1. 吸附 (Snap)
+      const snappedStart = turf.nearestPointOnLine(line, startPt);
+      const snappedEnd = turf.nearestPointOnLine(line, endPt);
+
+        // 2. 环线检测
+        const coords = line.geometry.coordinates;
+        const firstPt = coords[0];
+        const lastPt = coords[coords.length - 1];
+        const isLoop = turf.distance(turf.point(firstPt), turf.point(lastPt)) < 0.5;
+
+        // 3. 切分
+        let resultCoords = [];
+
+        if (!isLoop) {
+            const sliced = turf.lineSlice(snappedStart, snappedEnd, line);
+            resultCoords = sliced.geometry.coordinates;
+        } else {
+            const sliceDirect = turf.lineSlice(snappedStart, snappedEnd, line);
+            const lenDirect = turf.length(sliceDirect);
+
+            const sliceToTail = turf.lineSlice(snappedStart, turf.point(lastPt), line);
+            const sliceFromHead = turf.lineSlice(turf.point(firstPt), snappedEnd, line);
+            const lenWrap = turf.length(sliceToTail) + turf.length(sliceFromHead);
+
+            if (lenDirect <= lenWrap) {
+                resultCoords = sliceDirect.geometry.coordinates;
+            } else {
+                const c1 = sliceToTail.geometry.coordinates.map(p => [p[1], p[0]]);
+                const c2 = sliceFromHead.geometry.coordinates.map(p => [p[1], p[0]]);
+                return [c1, c2]; // MultiPolyline
+            }
+        }
+        return resultCoords.map(p => [p[1], p[0]]); // Leaflet [lat, lng]
+    } catch (e) {
+        console.warn("Turf slice failed:", e);
+        return null;
+    }
+};
+
+// 监听主线程消息
+self.addEventListener('message', async (e) => {
+    const { id, type, payload } = e.data;
+
+    try {
+        switch (type) {
+            case 'SYNC_DATA':
+                if (payload.railwayData) railwayData = payload.railwayData;
+                if (payload.geoData) geoData = payload.geoData;
+                self.postMessage({ id, type: 'SYNC_DATA_SUCCESS' });
+                break;
+
+            case 'GET_ALL_GEOMETRIES':
+                // 按需计算所需的 segments
+                const neededSegments = payload.segments || [];
+                const results = [];
+
+                for (const seg of neededSegments) {
+                    const key = `${seg.lineKey}_${seg.fromId}_${seg.toId}`;
+                    const line = railwayData[seg.lineKey];
+                    if (!line) {
+                        // 找不到路线数据，返回一个表示跳过的结果
+                        results.push({ key, data: null });
+                        continue;
+                    }
+
+                    const s1 = line.stations.find(s => s.id === seg.fromId);
+                    const s2 = line.stations.find(s => s.id === seg.toId);
+                    if (!s1 || !s2) {
+                        results.push({ key, data: null });
+                        continue;
+                    }
+
+                    const parts = seg.lineKey.split(':');
+                    const company = parts[0];
+                    const lineName = parts.slice(1).join(':');
+
+                    const feature = geoData.features.find((f) =>
+                        f.properties.type === 'line' &&
+                        f.properties.name === lineName &&
+                        f.properties.company === company
+                    );
+
+                    let coords = null;
+                    let color = '#38bdf8';
+                    let isMulti = false;
+                    let fallback = false;
+
+                    if (feature) {
+                        color = feature.properties.stroke || '#38bdf8';
+                        const latLngs = sliceGeoJsonPath(feature, s1.lat, s1.lng, s2.lat, s2.lng);
+                        if (latLngs) {
+                            coords = latLngs;
+                            if (Array.isArray(latLngs[0]) && Array.isArray(latLngs[0][0])) isMulti = true;
+                        }
+                    }
+
+                    // Fallback 逻辑：当没匹配到 GeoJSON，生成直线或各站直连
+                    if (!coords) {
+                        fallback = true;
+                        const routeCoords = [];
+                        const startIdx = line.stations.findIndex(st => st.id === seg.fromId);
+                        const endIdx = line.stations.findIndex(st => st.id === seg.toId);
+                        if (startIdx !== -1 && endIdx !== -1) {
+                            const step = startIdx <= endIdx ? 1 : -1;
+                            for (let i = startIdx; i !== endIdx + step; i += step) {
+                                if (i >= 0 && i < line.stations.length) routeCoords.push([line.stations[i].lat, line.stations[i].lng]);
+                            }
+                            if (routeCoords.length > 1) { coords = routeCoords; fallback = false; }
+                        }
+                    }
+
+                    if (!coords) {
+                        // 最差的情况，连接首尾两点
+                        coords = [[s1.lat, s1.lng], [s2.lat, s2.lng]];
+                        fallback = true;
+                    }
+
+                    results.push({
+                        key,
+                        data: { coords, color, isMulti, fallback }
+                    });
+                }
+
+                self.postMessage({ id, type: 'GET_ALL_GEOMETRIES_SUCCESS', payload: results });
+                break;
+
+            default:
+                self.postMessage({ id, type: 'ERROR', payload: 'Unknown message type' });
+        }
+    } catch (err) {
+        self.postMessage({ id, type: 'ERROR', payload: err.message });
+    }
+});


### PR DESCRIPTION
Fix map trajectory rendering by refactoring GeoWorker and resolving AppLayout computation deadlocks

- Implement `src/workers/geo.worker.js` to process heavy Turf.js geographical calculations like `sliceGeoJsonPath` asynchronously.
- Refactor `AppLayout.tsx` geometry calculation `useEffect` to avoid deadlocking the render thread: 
  - Immediately render cached map line segments while requesting missing geometries from the IndexedDB/Worker.
  - Implement a fallback cache line (`{ fallback: true }`) for corrupt/unmatchable trip segments to prevent infinite loops of worker requests.
  - Add debounce (`setTimeout`) to geometry `useEffect` triggers to optimize performance during high-frequency trip edits.
- Fix KML export relying on outdated synchronous map computations.

---
*PR created automatically by Jules for task [11557661365920591601](https://jules.google.com/task/11557661365920591601) started by @OsakaLOOP*