### PR TITLE
Fix Pin Mode interaction and validation flow

### DIFF
--- a/patch_fabbutton.js
+++ b/patch_fabbutton.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+let file = 'src/components/map/FabButton.tsx';
+let content = fs.readFileSync(file, 'utf-8');
+
+const search = `        else if (pinMode === PinMode.Free) {
+            setPinMode(PinMode.Snap);
+            if (editingPin) {
+                // We'll let PinEditor or MapContainer handle snapping initially, but to emulate
+                // RailRound.jsx behavior precisely: snap immediately when transitioning to Snap mode.
+                // However, railwayData is needed. Let's dispatch an event for MapContainer to handle this too,
+                // OR we can fetch railwayData from store here. Let's fetch it from store here for simplicity.
+                const railwayData = useStore.getState().railwayData;
+                import('../../utils/railwayRouting').then(({ findNearestPointOnLine }) => {
+                    const snap = findNearestPointOnLine(railwayData, editingPin.lat, editingPin.lng);
+                    setEditingPin({ ...editingPin, ...snap });
+                });
+            }
+        }`;
+
+const replace = `        else if (pinMode === PinMode.Free) {
+            setPinMode(PinMode.Snap);
+            if (editingPin) {
+                const railwayData = useStore.getState().railwayData;
+                import('../../utils/railwayRouting').then(({ findNearestPointOnLine }) => {
+                    const snap = findNearestPointOnLine(railwayData, editingPin.lat, editingPin.lng);
+                    setEditingPin({ ...editingPin, ...snap });
+                });
+            }
+        }`;
+content = content.replace(search, replace);
+fs.writeFileSync(file, content);

--- a/patch_mapcontainer.js
+++ b/patch_mapcontainer.js
@@ -1,161 +1,26 @@
 const fs = require('fs');
+let content = fs.readFileSync('src/components/map/MapContainer.tsx', 'utf-8');
 
-const filepath = 'src/components/map/MapContainer.tsx';
-let source = fs.readFileSync(filepath, 'utf8');
+// Insert useEffect for listening 'map:create-temp-pin'
+const hookSearch = `    useEffect(() => {
+        if (isMapInitialized && leafletReady && !isDraggingRef.current) renderPins();
+    }, [pins, editingPin, pinMode, leafletReady, isMapInitialized]);`;
 
-// 1. Add geoDataRef to MapContainer component
-source = source.replace(
-    /const baseStationsLayer = useRef<L\.LayerGroup \| null>\(null\);/g,
-    `const baseStationsLayer = useRef<L.LayerGroup | null>(null);\n    const geoDataRef = useRef<CustomFeatureCollection | null>(null);`
-);
+const hookReplace = `    useEffect(() => {
+        if (isMapInitialized && leafletReady && !isDraggingRef.current) renderPins();
+    }, [pins, editingPin, pinMode, leafletReady, isMapInitialized]);
 
-// 2. Update geoDataRef whenever geoData changes
-source = source.replace(
-    /useEffect\(\(\) => \{\n        if \(isMapInitialized && leafletReady && geoData\) renderBaseMap\(geoData\);\n    \}, \[geoData, leafletReady, isMapInitialized\]\);/g,
-    `useEffect(() => {
-        geoDataRef.current = geoData;
-        if (isMapInitialized && leafletReady && geoData) {
-            renderBaseMap(geoData);
-            renderStations();
-        }
-    }, [geoData, leafletReady, isMapInitialized]);`
-);
+    useEffect(() => {
+        const handleCreateTempPin = () => {
+            if (!mapInstance.current) return;
+            const c = mapInstance.current.getCenter();
+            setEditingPin({ id: 'temp', lat: c.lat, lng: c.lng, type: 'photo', color: '#ef4444', isTemp: true } as any);
+            mapInstance.current.panBy([0, 150]);
+        };
+        window.addEventListener('map:create-temp-pin', handleCreateTempPin);
+        return () => window.removeEventListener('map:create-temp-pin', handleCreateTempPin);
+    }, [setEditingPin]);`;
 
-// 3. Add map event listener for moveend (dragend & zoomend combined)
-source = source.replace(
-    /map\.on\('zoomend', updateLayerVisibility\);\n        updateLayerVisibility\(\);/g,
-    `map.on('zoomend', updateLayerVisibility);
-        updateLayerVisibility();
+content = content.replace(hookSearch, hookReplace);
 
-        // Listen to moveend to update stations with new bounds
-        map.on('moveend', () => {
-            renderStations();
-        });`
-);
-
-// 4. Create the renderStations method and modify renderBaseMap
-// Extract the baseStationsLayer part from renderBaseMap
-const stationsLogic = `
-        // Base Stations
-        const stationFeatures = data.features.filter((f: CustomGeoJSONFeature) => f.properties.type === 'station');
-        syncLeafletLayerGroup<CustomGeoJSONFeature>(
-            baseStationsLayer.current,
-            stationFeatures,
-            (f) => f.properties.id || \`\${f.properties.company}:\${f.properties.line}:\${f.properties.name}\`,
-            (f) => {
-                const latlng = [f.geometry.coordinates[1], f.geometry.coordinates[0]] as [number, number];
-                const layer = L.circleMarker(latlng, { radius: 4, color: 'transparent', fillColor: '#64748b', fillOpacity: 0.5, weight: 0, className: 'station-dot' });
-                if (f.properties.name) layer.bindTooltip(f.properties.name);
-                layer.on('click', (e: L.LeafletMouseEvent) => {
-                    L.DomEvent.stopPropagation(e);
-                    const originalEvent = e.originalEvent as MouseEvent | TouchEvent;
-                    const x = 'clientX' in originalEvent ? originalEvent.clientX : (originalEvent as TouchEvent).touches[0].clientX;
-                    const y = 'clientY' in originalEvent ? originalEvent.clientY : (originalEvent as TouchEvent).touches[0].clientY;
-                    setStationMenu({ x, y, stationData: { name_ja: f.properties.name || '' } });
-                });
-                return layer;
-            },
-            (layer, f) => {
-                // Stations static
-            }
-        );`;
-
-source = source.replace(stationsLogic, "");
-
-const renderStationsMethod = `
-    const renderStations = () => {
-        if (!baseStationsLayer.current || !mapInstance.current || !geoDataRef.current) return;
-
-        const map = mapInstance.current;
-        const currentZoom = map.getZoom();
-
-        // At zoom < 5, strictly provide empty array to clear/hide stations
-        if (currentZoom < 5) {
-            syncLeafletLayerGroup<CustomGeoJSONFeature>(
-                baseStationsLayer.current,
-                [],
-                (f) => f.properties.id || \`\${f.properties.company}:\${f.properties.line}:\${f.properties.name}\`,
-                (f) => L.circleMarker([0, 0]),
-                () => {}
-            );
-            return;
-        }
-
-        // Calculate 3x3 viewport bounds
-        const bounds = map.getBounds();
-        const latDiff = bounds.getNorth() - bounds.getSouth();
-        const lngDiff = bounds.getEast() - bounds.getWest();
-
-        const expandedBounds = L.latLngBounds(
-            L.latLng(bounds.getSouth() - latDiff, bounds.getWest() - lngDiff),
-            L.latLng(bounds.getNorth() + latDiff, bounds.getEast() + lngDiff)
-        );
-
-        // Filter stations within the expanded bounds
-        const stationFeatures = geoDataRef.current.features.filter((f: CustomGeoJSONFeature) => {
-            if (f.properties.type !== 'station') return false;
-            const lng = f.geometry.coordinates[0];
-            const lat = f.geometry.coordinates[1];
-            // Since it's point data, check if it's within the expanded bounds
-            return expandedBounds.contains([lat, lng]);
-        });
-
-        syncLeafletLayerGroup<CustomGeoJSONFeature>(
-            baseStationsLayer.current,
-            stationFeatures,
-            (f) => f.properties.id || \`\${f.properties.company}:\${f.properties.line}:\${f.properties.name}\`,
-            (f) => {
-                const latlng = [f.geometry.coordinates[1], f.geometry.coordinates[0]] as [number, number];
-                const layer = L.circleMarker(latlng, { radius: 4, color: 'transparent', fillColor: '#64748b', fillOpacity: 0.5, weight: 0, className: 'station-dot' });
-                if (f.properties.name) layer.bindTooltip(f.properties.name);
-
-                (layer as any)._cachedLat = latlng[0];
-                (layer as any)._cachedLng = latlng[1];
-                (layer as any)._cachedName = f.properties.name;
-
-                layer.on('click', (e: L.LeafletMouseEvent) => {
-                    L.DomEvent.stopPropagation(e);
-                    const originalEvent = e.originalEvent as MouseEvent | TouchEvent;
-                    const x = 'clientX' in originalEvent ? originalEvent.clientX : (originalEvent as TouchEvent).touches[0].clientX;
-                    const y = 'clientY' in originalEvent ? originalEvent.clientY : (originalEvent as TouchEvent).touches[0].clientY;
-                    setStationMenu({ x, y, stationData: { name_ja: f.properties.name || '' } });
-                });
-                return layer;
-            },
-            (layer, f) => {
-                const marker = layer as L.CircleMarker & { _cachedLat?: number, _cachedLng?: number, _cachedName?: string };
-                const newLat = f.geometry.coordinates[1];
-                const newLng = f.geometry.coordinates[0];
-                const newName = f.properties.name;
-
-                let changed = false;
-                if (marker._cachedLat !== newLat || marker._cachedLng !== newLng) {
-                    marker.setLatLng([newLat, newLng]);
-                    marker._cachedLat = newLat;
-                    marker._cachedLng = newLng;
-                    changed = true;
-                }
-
-                if (marker._cachedName !== newName) {
-                    marker.unbindTooltip();
-                    if (newName) marker.bindTooltip(newName);
-                    marker._cachedName = newName;
-                    changed = true;
-                }
-
-                // Do nothing else if not changed to optimize DOM updates
-            }
-        );
-    };
-`;
-
-source = source.replace(/const renderBaseMap = \(data: CustomFeatureCollection\) => \{/, renderStationsMethod + '\n    const renderBaseMap = (data: CustomFeatureCollection) => {');
-
-// We also need to remove the requirement for baseStationsLayer in renderBaseMap since we removed the logic
-source = source.replace(
-    /if \(!baseLinesLayer\.current \|\| !baseStationsLayer\.current\) return;/g,
-    `if (!baseLinesLayer.current) return;`
-);
-
-fs.writeFileSync(filepath, source, 'utf8');
-console.log("Patched successfully!");
+fs.writeFileSync('src/components/map/MapContainer.tsx', content);

--- a/patch_mapcontainer2.js
+++ b/patch_mapcontainer2.js
@@ -1,27 +1,64 @@
 const fs = require('fs');
+let content = fs.readFileSync('src/components/map/MapContainer.tsx', 'utf-8');
 
-const filepath = 'src/components/map/MapContainer.tsx';
-let source = fs.readFileSync(filepath, 'utf8');
+// Use current store state in map.on('click') is already done using useStore.getState()
+// Let's check renderPins logic to use useStore.getState().pinMode instead of closure pinMode
 
-source = source.replace(
-    /const marker = layer as L\.CircleMarker & \{ _cachedLat\?: number, _cachedLng\?: number, _cachedName\?: string \};/g,
-    `const marker = layer as any;`
-);
+const dragStartSearch = `                marker.on('dragstart', () => {
+                    isDraggingRef.current = true;
+                    setEditingPin({ ...pin });
+                    if (pinMode === PinMode.Idle) setPinMode(PinMode.Free);
+                });`;
 
-source = source.replace(
-    /\(layer as any\)\._cachedLat = latlng\[0\];/g,
-    `// @ts-ignore\n                layer._cachedLat = latlng[0];`
-);
+const dragStartReplace = `                marker.on('dragstart', () => {
+                    isDraggingRef.current = true;
+                    setEditingPin({ ...pin });
+                    const currentPinMode = useStore.getState().pinMode;
+                    if (currentPinMode === PinMode.Idle) setPinMode(PinMode.Free);
+                });`;
 
-source = source.replace(
-    /\(layer as any\)\._cachedLng = latlng\[1\];/g,
-    `// @ts-ignore\n                layer._cachedLng = latlng[1];`
-);
+content = content.replace(dragStartSearch, dragStartReplace);
 
-source = source.replace(
-    /\(layer as any\)\._cachedName = f\.properties\.name;/g,
-    `// @ts-ignore\n                layer._cachedName = f.properties.name;`
-);
+const dragEndSearch = `                marker.on('dragend', (e) => {
+                    isDraggingRef.current = false;
+                    const { lat, lng } = e.target.getLatLng();
+                    let newPos = { lat, lng, lineKey: pin.lineKey, percentage: pin.percentage };
+                    if (pinMode === PinMode.Snap) {
+                        const snap = findNearestPointOnLine(useStore.getState().railwayData, lat, lng);
+                        newPos = { ...newPos, ...snap };
+                        e.target.setLatLng(newPos);
+                    }
+                    setEditingPin((prev) => prev && prev.id === pin.id ? { ...prev, ...newPos } : { ...pin, ...newPos });
+                    if (pinMode === PinMode.Idle) setPinMode(PinMode.Free);
+                });`;
 
-fs.writeFileSync(filepath, source, 'utf8');
-console.log("Patched MapContainer.tsx!");
+const dragEndReplace = `                marker.on('dragend', (e) => {
+                    isDraggingRef.current = false;
+                    const { lat, lng } = e.target.getLatLng();
+                    let newPos = { lat, lng, lineKey: pin.lineKey, percentage: pin.percentage };
+                    const currentPinMode = useStore.getState().pinMode;
+                    if (currentPinMode === PinMode.Snap) {
+                        const snap = findNearestPointOnLine(useStore.getState().railwayData, lat, lng);
+                        newPos = { ...newPos, ...snap };
+                        e.target.setLatLng(newPos);
+                    }
+                    setEditingPin((prev) => prev && prev.id === pin.id ? { ...prev, ...newPos } : { ...pin, ...newPos });
+                    if (currentPinMode === PinMode.Idle) setPinMode(PinMode.Free);
+                });`;
+
+content = content.replace(dragEndSearch, dragEndReplace);
+
+const clickSearch = `                marker.on('click', () => {
+                    setEditingPin(pin);
+                    if (pinMode === PinMode.Idle) setPinMode(PinMode.Free);
+                });`;
+
+const clickReplace = `                marker.on('click', () => {
+                    setEditingPin(pin);
+                    const currentPinMode = useStore.getState().pinMode;
+                    if (currentPinMode === PinMode.Idle) setPinMode(PinMode.Free);
+                });`;
+
+content = content.replace(clickSearch, clickReplace);
+
+fs.writeFileSync('src/components/map/MapContainer.tsx', content);

--- a/patch_pineditor.js
+++ b/patch_pineditor.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+let content = fs.readFileSync('src/components/map/PinEditor.tsx', 'utf-8');
+
+const search = `    const deletePin = (id: string | number) => {
+        if(confirm('删除?')) {
+            const newPins = pins.filter(p => p.id !== id);
+            setPins(newPins);
+            if (editingPin?.id === id) setEditingPin(null);
+        }
+    };`;
+
+const replace = `    const deletePin = (id: string | number) => {
+        if(confirm('删除?')) {
+            const newPins = pins.filter(p => p.id !== id);
+            setPins(newPins);
+            if (editingPin?.id === id) {
+                setEditingPin(null);
+                setPinMode(PinMode.Idle);
+            }
+        }
+    };`;
+
+content = content.replace(search, replace);
+fs.writeFileSync('src/components/map/PinEditor.tsx', content);

--- a/src/components/map/FabButton.tsx
+++ b/src/components/map/FabButton.tsx
@@ -15,13 +15,18 @@ export const FabButton: React.FC = () => {
     const togglePinMode = () => {
         if (pinMode === PinMode.Idle) {
             setPinMode(PinMode.Free);
-            // Trigger temporary pin logic handled elsewhere or we mock here
-            // Note: need map instance for center. For simplicity, handled mostly in MapContainer click
-            // For robust temp pin creation, ideally it requests center from store or map.
+            // Dispatch a custom event so MapContainer can create the temp pin and pan the map
+            window.dispatchEvent(new CustomEvent('map:create-temp-pin'));
         }
         else if (pinMode === PinMode.Free) {
             setPinMode(PinMode.Snap);
-            // Snap logic handled by PinEditor or MapContainer dragend
+            if (editingPin) {
+                const railwayData = useStore.getState().railwayData;
+                import('../../utils/railwayRouting').then(({ findNearestPointOnLine }) => {
+                    const snap = findNearestPointOnLine(railwayData, editingPin.lat, editingPin.lng);
+                    setEditingPin({ ...editingPin, ...snap });
+                });
+            }
         }
         else {
             setPinMode(PinMode.Idle);

--- a/src/components/map/MapContainer.tsx
+++ b/src/components/map/MapContainer.tsx
@@ -71,6 +71,17 @@ export const MapContainer: React.FC<Props> = ({ setStationMenu, isDraggingRef })
         if (isMapInitialized && leafletReady && !isDraggingRef.current) renderPins();
     }, [pins, editingPin, pinMode, leafletReady, isMapInitialized]);
 
+    useEffect(() => {
+        const handleCreateTempPin = () => {
+            if (!mapInstance.current) return;
+            const c = mapInstance.current.getCenter();
+            setEditingPin({ id: 'temp', lat: c.lat, lng: c.lng, type: 'photo', color: '#ef4444', isTemp: true } as any);
+            mapInstance.current.panBy([0, 150]);
+        };
+        window.addEventListener('map:create-temp-pin', handleCreateTempPin);
+        return () => window.removeEventListener('map:create-temp-pin', handleCreateTempPin);
+    }, [setEditingPin]);
+
     const initMap = () => {
         if (!mapRef.current || mapInstance.current ) return;
         const map = L.map(mapRef.current, { zoomControl: true, preferCanvas: true }).setView([35.68, 139.76], 10);
@@ -317,23 +328,26 @@ export const MapContainer: React.FC<Props> = ({ setStationMenu, isDraggingRef })
                 marker.on('dragstart', () => {
                     isDraggingRef.current = true;
                     setEditingPin({ ...pin });
-                    if (pinMode === PinMode.Idle) setPinMode(PinMode.Free);
+                    const currentPinMode = useStore.getState().pinMode;
+                    if (currentPinMode === PinMode.Idle) setPinMode(PinMode.Free);
                 });
                 marker.on('dragend', (e) => {
                     isDraggingRef.current = false;
                     const { lat, lng } = e.target.getLatLng();
                     let newPos = { lat, lng, lineKey: pin.lineKey, percentage: pin.percentage };
-                    if (pinMode === PinMode.Snap) {
+                    const currentPinMode = useStore.getState().pinMode;
+                    if (currentPinMode === PinMode.Snap) {
                         const snap = findNearestPointOnLine(useStore.getState().railwayData, lat, lng);
                         newPos = { ...newPos, ...snap };
                         e.target.setLatLng(newPos);
                     }
                     setEditingPin((prev) => prev && prev.id === pin.id ? { ...prev, ...newPos } : { ...pin, ...newPos });
-                    if (pinMode === PinMode.Idle) setPinMode(PinMode.Free);
+                    if (currentPinMode === PinMode.Idle) setPinMode(PinMode.Free);
                 });
                 marker.on('click', () => {
                     setEditingPin(pin);
-                    if (pinMode === PinMode.Idle) setPinMode(PinMode.Free);
+                    const currentPinMode = useStore.getState().pinMode;
+                    if (currentPinMode === PinMode.Idle) setPinMode(PinMode.Free);
                 });
                 return marker;
             },

--- a/src/components/map/PinEditor.tsx
+++ b/src/components/map/PinEditor.tsx
@@ -30,7 +30,10 @@ export const PinEditor: React.FC = () => {
         if(confirm('删除?')) {
             const newPins = pins.filter(p => p.id !== id);
             setPins(newPins);
-            if (editingPin?.id === id) setEditingPin(null);
+            if (editingPin?.id === id) {
+                setEditingPin(null);
+                setPinMode(PinMode.Idle);
+            }
         }
     };
 


### PR DESCRIPTION
Restored the missing feature that lets users create a temporary map pin at the center of the viewport via `MapContainer`. Ensures correctly fetching the latest store states from Leaflet layer event callbacks without triggering unbounded re-renders. Fixed snap action to execute right away in `FabButton` when switched to Snap Mode. Reset `pinMode` gracefully when the currently editing pin is deleted.

---
*PR created automatically by Jules for task [16364887307951874081](https://jules.google.com/task/16364887307951874081) started by @OsakaLOOP*