### PR TITLE
fix: restore cloud sync and KML export functionality with Zustand

### DIFF
--- a/src/AppLayout.tsx
+++ b/src/AppLayout.tsx
@@ -60,6 +60,40 @@ export const AppLayout: React.FC = () => {
     const isDraggingRef = useRef(false);
     const workerRef = useRef<Worker | null>(null);
 
+    // --- Login & URL Parsing (OAuth) ---
+    useEffect(() => {
+        const urlParams = new URLSearchParams(window.location.search);
+        const tokenFromUrl = urlParams.get('token');
+        const usernameFromUrl = urlParams.get('username');
+        const regTokenFromUrl = urlParams.get('reg_token');
+        const status = urlParams.get('status');
+
+        if (tokenFromUrl && usernameFromUrl) {
+            useStore.getState().login(tokenFromUrl, usernameFromUrl);
+            window.history.replaceState({}, document.title, window.location.pathname);
+        } else if (regTokenFromUrl) {
+            setModalState({ isGithubRegOpen: true, githubRegToken: regTokenFromUrl });
+            window.history.replaceState({}, document.title, window.location.pathname);
+        } else {
+            const token = localStorage.getItem('rail_token');
+            const username = localStorage.getItem('rail_username');
+            if (token && username) {
+                // For auto-login from local storage, do not prompt for merge
+                useStore.setState({ isLoggedIn: true, user: { token, username } });
+                useStore.getState().loadUserData(token, false);
+            }
+        }
+
+        if (status === 'bound_success') {
+            alert("GitHub 绑定成功！");
+            window.history.replaceState({}, document.title, window.location.pathname);
+            const token = localStorage.getItem('rail_token');
+            if (token) {
+                useStore.getState().loadUserData(token);
+            }
+        }
+    }, [setModalState]);
+
     // --- Worker Setup ---
     useEffect(() => {
         workerRef.current = new GeoWorker();
@@ -370,15 +404,39 @@ export const AppLayout: React.FC = () => {
         setTimeout(async () => {
             try {
                 if (trips.length === 0 || !geoData) { alert("无行程记录或地图数据未加载。"); setIsExportingKML(false); return; }
-                const allPaths: any[] = [];
 
-                // 由于 sliceGeoJsonPath 已移至 Worker，我们需要用另一种方式处理 KML 导出。
-                // 最简单的方法是重用现有的 segmentGeometries 缓存！
+                const allSegments = trips.flatMap(t => t.segments || []);
+                const neededSegments = allSegments.filter(seg => {
+                    if (!seg.lineKey || !seg.fromId || !seg.toId) return false;
+                    return !segmentGeometries.has(`${seg.lineKey}_${seg.fromId}_${seg.toId}`);
+                });
+
+                if (neededSegments.length > 0 && workerRef.current) {
+                    try {
+                        const results = await callWorker('GET_ALL_GEOMETRIES', { segments: neededSegments });
+                        const newCache = new Map(segmentGeometries);
+                        for (const res of results) {
+                            const { key, data } = res;
+                            if (data && !data.fallback) {
+                                newCache.set(key, data);
+                                await db.set(db.STORE_SEGMENTS, key, data);
+                            }
+                        }
+                        setSegmentGeometries(newCache);
+                    } catch (e) {
+                        console.error("Worker Geo Calc failed during KML Export:", e);
+                    }
+                }
+
+                // Make sure we read from the latest updated cache
+                const currentCache = useStore.getState().segmentGeometries;
+
+                const allPaths: any[] = [];
                 trips.forEach(t => {
                     const tripName = `${t.date} - Trip ${t.id}`;
                     t.segments.forEach((seg: any, segIndex: number) => {
                         const key = `${seg.lineKey}_${seg.fromId}_${seg.toId}`;
-                        const cached = segmentGeometries.get(key);
+                        const cached = currentCache.get(key);
                         if (cached && cached.coords) {
                             const coords = cached.coords;
                             const kmlCoords = cached.isMulti

--- a/src/components/modals/AddToFolderModal.tsx
+++ b/src/components/modals/AddToFolderModal.tsx
@@ -2,12 +2,17 @@ import React, { useEffect } from 'react';
 import { X, Star, CheckCircle2 } from 'lucide-react';
 import { useStore } from '../../store';
 import { useShallow } from 'zustand/react/shallow';
+import { calculateLatestStats } from '../../utils/stats';
 
 export const AddToFolderModal: React.FC = () => {
-    const { isOpen, trip, folders } = useStore(useShallow(state => ({
+    const { isOpen, trip, folders, trips, segmentGeometries, railwayData, geoData } = useStore(useShallow(state => ({
         isOpen: state.modals.addToFolderModalOpen,
         trip: state.modals.currentTripForFolder,
-        folders: state.folders
+        folders: state.folders,
+        trips: state.trips,
+        segmentGeometries: state.segmentGeometries,
+        railwayData: state.railwayData,
+        geoData: state.geoData
     })));
     const setModalState = useStore(state => state.setModalState);
     const setFolders = useStore(state => state.setFolders);
@@ -34,7 +39,17 @@ export const AddToFolderModal: React.FC = () => {
                 } else {
                     currentIds.add(trip.id);
                 }
-                return { ...f, trip_ids: Array.from(currentIds) };
+                const newIds = Array.from(currentIds);
+
+                // Recalculate stats for modified folder
+                let stats = null;
+                if (newIds.length > 0) {
+                    const folderTrips = trips.filter(t => newIds.includes(t.id));
+                    folderTrips.sort((a,b) => b.date.localeCompare(a.date));
+                    stats = calculateLatestStats(folderTrips, segmentGeometries, railwayData, geoData);
+                }
+
+                return { ...f, trip_ids: newIds, stats };
             }
             return f;
         });

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,5 +1,10 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import { api } from '../services/api';
+import { calculateLatestStats } from '../utils/stats';
+import changelogData from '../../public/changelog.json';
+
+const CURRENT_VERSION = changelogData.meta["currentVersion"];
 
 // basic value
 export type ID = string | number;
@@ -174,6 +179,9 @@ export interface GlobalStore {
   setFolders: (folders: Folder[] | ((prev: Folder[]) => Folder[])) => void;
   setBadgeSettings: (settings: BadgeSettings) => void;
 
+  syncDataToCloud: () => Promise<void>;
+  loadUserData: (token: string, isInteractive?: boolean) => Promise<void>;
+
   // UI Slice
   activeTab: 'records' | 'map' | 'stats';
   setActiveTab: (tab: 'records' | 'map' | 'stats') => void;
@@ -239,22 +247,123 @@ export const useStore = create<GlobalStore>()(
       folders: [],
       badgeSettings: { enabled: true },
 
-      login: (token, username) => set({ isLoggedIn: true, user: { token, username } }),
-      logout: () => set({ isLoggedIn: false, user: null, userProfile: null }),
+      login: (token, username) => {
+          localStorage.setItem('rail_token', token);
+          localStorage.setItem('rail_username', username);
+          set({ isLoggedIn: true, user: { token, username } });
+          get().loadUserData(token, true);
+      },
+      logout: () => {
+          localStorage.removeItem('rail_token');
+          localStorage.removeItem('rail_username');
+          set({ isLoggedIn: false, user: null, userProfile: null });
+      },
       setUserProfile: (profile) => set({ userProfile: profile }),
 
-      setTrips: (input) => set((state) => ({ trips: typeof input === 'function' ? input(state.trips) : input })),
-      addTrip: (trip) => set((state) => ({ trips: [trip, ...state.trips].sort((a,b) => b.date.localeCompare(a.date)) })),
-      updateTrip: (trip) => set((state) => ({ trips: state.trips.map(t => t.id === trip.id ? trip : t).sort((a,b) => b.date.localeCompare(a.date)) })),
-      removeTrip: (id) => set((state) => ({ trips: state.trips.filter(t => t.id !== id) })),
+      syncDataToCloud: async () => {
+          const state = get();
+          if (!state.user) return;
+          try {
+              const latest5 = calculateLatestStats(state.trips, state.segmentGeometries, state.railwayData, state.geoData);
+              await api.saveData(state.user.token, state.trips, state.pins, latest5, CURRENT_VERSION, state.folders, state.badgeSettings);
+          } catch (e: any) {
+              console.error('Failed to sync data to cloud:', e);
+              // alert('云端同步失败: ' + e.message); // Consider a non-blocking toast
+          }
+      },
 
-      setPins: (input) => set((state) => ({ pins: typeof input === 'function' ? input(state.pins) : input })),
-      addPin: (pin) => set((state) => ({ pins: [...state.pins, pin] })),
-      updatePin: (pin) => set((state) => ({ pins: state.pins.map(p => p.id === pin.id ? pin : p) })),
-      removePin: (id) => set((state) => ({ pins: state.pins.filter(p => p.id !== id) })),
+      loadUserData: async (token, isInteractive = false) => {
+          try {
+              const cloudData = await api.getData(token);
+              set({ userProfile: cloudData });
 
-      setFolders: (input) => set((state) => ({ folders: typeof input === 'function' ? input(state.folders) : input })),
-      setBadgeSettings: (settings) => set({ badgeSettings: settings }),
+              let newTrips = cloudData.trips || [];
+              let newPins = cloudData.pins || [];
+              let newFolders = cloudData.folders || [];
+              let newBadgeSettings = cloudData.badge_settings || { enabled: true };
+
+              const state = get();
+
+              if (isInteractive && (state.trips.length > 0 || state.pins.length > 0)) {
+                  if (confirm("检测到本地有数据，是否保留并与云端数据合并？\n\n点击【确定】合并 (Keep Local)\n点击【取消】仅使用云端数据 (Overwrite Local)")) {
+                      const tripMap = new Map();
+                      newTrips.forEach((t: Trip) => tripMap.set(t.id, t));
+                      state.trips.forEach((t: Trip) => tripMap.set(t.id, t));
+                      newTrips = Array.from(tripMap.values());
+
+                      const pinMap = new Map();
+                      newPins.forEach((p: Pin) => pinMap.set(p.id, p));
+                      state.pins.forEach((p: Pin) => pinMap.set(p.id, p));
+                      newPins = Array.from(pinMap.values());
+
+                      set({
+                          trips: newTrips.sort((a: any, b: any) => b.date.localeCompare(a.date)),
+                          pins: newPins,
+                          folders: newFolders,
+                          badgeSettings: newBadgeSettings
+                      });
+                      get().syncDataToCloud();
+                      return;
+                  }
+              }
+
+              set({
+                  trips: newTrips.sort((a: any, b: any) => b.date.localeCompare(a.date)),
+                  pins: newPins,
+                  folders: newFolders,
+                  badgeSettings: newBadgeSettings
+              });
+              console.log('User data loaded');
+          } catch (e: any) {
+              console.error('Failed to load user data:', e);
+              if (e.message.includes('Unauthorized')) {
+                  get().logout();
+              }
+          }
+      },
+
+      setTrips: (input) => {
+          set((state) => ({ trips: typeof input === 'function' ? input(state.trips) : input }));
+          get().syncDataToCloud();
+      },
+      addTrip: (trip) => {
+          set((state) => ({ trips: [trip, ...state.trips].sort((a,b) => b.date.localeCompare(a.date)) }));
+          get().syncDataToCloud();
+      },
+      updateTrip: (trip) => {
+          set((state) => ({ trips: state.trips.map(t => t.id === trip.id ? trip : t).sort((a,b) => b.date.localeCompare(a.date)) }));
+          get().syncDataToCloud();
+      },
+      removeTrip: (id) => {
+          set((state) => ({ trips: state.trips.filter(t => t.id !== id) }));
+          get().syncDataToCloud();
+      },
+
+      setPins: (input) => {
+          set((state) => ({ pins: typeof input === 'function' ? input(state.pins) : input }));
+          get().syncDataToCloud();
+      },
+      addPin: (pin) => {
+          set((state) => ({ pins: [...state.pins, pin] }));
+          get().syncDataToCloud();
+      },
+      updatePin: (pin) => {
+          set((state) => ({ pins: state.pins.map(p => p.id === pin.id ? pin : p) }));
+          get().syncDataToCloud();
+      },
+      removePin: (id) => {
+          set((state) => ({ pins: state.pins.filter(p => p.id !== id) }));
+          get().syncDataToCloud();
+      },
+
+      setFolders: (input) => {
+          set((state) => ({ folders: typeof input === 'function' ? input(state.folders) : input }));
+          get().syncDataToCloud();
+      },
+      setBadgeSettings: (settings) => {
+          set({ badgeSettings: settings });
+          get().syncDataToCloud();
+      },
 
       // --- UI Slice ---
       activeTab: 'records',


### PR DESCRIPTION
This commit restores critical features lost during the transition from `RailRound.jsx` to Zustand state management:

1. **Cloud Sync**: Re-implemented `syncDataToCloud` inside the Zustand store and linked it to all state mutators.
2. **KML Export**: Fixed the `handleExportKML` function to actively fetch missing geometries via the web worker before creating the KML.
3. **Folder Badges**: Ensure the `stats` property is updated on the folder object when trips are modified inside the `AddToFolderModal`.
4. **Auto-Login Bug**: Fixed a UX bug where a user with a local storage token would repeatedly get the "merge data" dialog on page load by passing `isInteractive = false`.

---
*PR created automatically by Jules for task [4110865874257790014](https://jules.google.com/task/4110865874257790014) started by @OsakaLOOP*