### PR TITLE
Refactor Zustand useShallow dependencies for performance and clarity

### DIFF
--- a/src/AppLayout.tsx
+++ b/src/AppLayout.tsx
@@ -29,31 +29,28 @@ const CURRENT_VERSION = meta["currentVersion"];
 
 export const AppLayout: React.FC = () => {
     const {
-        activeTab, user, setModalState, setCompanyDB, setRailwayData, setGeoData,
-        trips, pins, railwayData, geoData, companyDB, setTrips, setPins, folders, badgeSettings,
-        setSegmentGeometries, setTripSegmentsGeometry, segmentGeometries,
-        isLoginOpen
+        activeTab, user, trips, pins, railwayData, geoData, companyDB, folders, badgeSettings, segmentGeometries, isLoginOpen
     } = useStore(useShallow(state => ({
         activeTab: state.activeTab,
         user: state.user,
-        setModalState: state.setModalState,
-        setCompanyDB: state.setCompanyDB,
-        setRailwayData: state.setRailwayData,
-        setGeoData: state.setGeoData,
         trips: state.trips,
         pins: state.pins,
         railwayData: state.railwayData,
         geoData: state.geoData,
         companyDB: state.companyDB,
-        setTrips: state.setTrips,
-        setPins: state.setPins,
         folders: state.folders,
         badgeSettings: state.badgeSettings,
-        setSegmentGeometries: state.setSegmentGeometries,
-        setTripSegmentsGeometry: state.setTripSegmentsGeometry,
         segmentGeometries: state.segmentGeometries,
         isLoginOpen: state.modals.isLoginOpen
     })));
+    const setModalState = useStore(state => state.setModalState);
+    const setCompanyDB = useStore(state => state.setCompanyDB);
+    const setRailwayData = useStore(state => state.setRailwayData);
+    const setGeoData = useStore(state => state.setGeoData);
+    const setTrips = useStore(state => state.setTrips);
+    const setPins = useStore(state => state.setPins);
+    const setSegmentGeometries = useStore(state => state.setSegmentGeometries);
+    const setTripSegmentsGeometry = useStore(state => state.setTripSegmentsGeometry);
 
     const [stationMenu, setStationMenu] = useState<any>(null);
     const [isExportingKML, setIsExportingKML] = useState(false);

--- a/src/components/layout/BottomNav.tsx
+++ b/src/components/layout/BottomNav.tsx
@@ -4,10 +4,12 @@ import { useStore } from '../../store';
 import { useShallow } from 'zustand/react/shallow';
 
 export const BottomNav: React.FC = () => {
-    const { activeTab, setActiveTab } = useStore(useShallow(state => ({
-        activeTab: state.activeTab,
-        setActiveTab: state.setActiveTab
+    const {
+        activeTab
+    } = useStore(useShallow(state => ({
+        activeTab: state.activeTab
     })));
+    const setActiveTab = useStore(state => state.setActiveTab);
 
     return (
         <nav className="bg-white border-t p-2 flex justify-around shrink-0 pb-safe z-30">

--- a/src/components/map/FabButton.tsx
+++ b/src/components/map/FabButton.tsx
@@ -4,13 +4,15 @@ import { useStore, PinMode } from '../../store';
 import { useShallow } from 'zustand/react/shallow';
 
 export const FabButton: React.FC = () => {
-    const { activeTab, pinMode, editingPin, setPinMode, setEditingPin } = useStore(useShallow(state => ({
+    const {
+        activeTab, pinMode, editingPin
+    } = useStore(useShallow(state => ({
         activeTab: state.activeTab,
         pinMode: state.pinMode,
-        editingPin: state.editingPin,
-        setPinMode: state.setPinMode,
-        setEditingPin: state.setEditingPin
+        editingPin: state.editingPin
     })));
+    const setPinMode = useStore(state => state.setPinMode);
+    const setEditingPin = useStore(state => state.setEditingPin);
 
     const togglePinMode = () => {
         if (pinMode === PinMode.Idle) {

--- a/src/components/map/MapContainer.tsx
+++ b/src/components/map/MapContainer.tsx
@@ -23,24 +23,22 @@ export const MapContainer: React.FC<Props> = ({ setStationMenu, isDraggingRef })
     const [isMapInitialized, setIsMapInitialized] = React.useState(false);
 
     const {
-        geoData, leafletReady, tripSegmentsGeometry, activeTab, mapZoom,
-        setMapZoom, setLeafletReady, pins, editingPin, pinMode, railwayData,
-        setEditingPin, setPinMode
+        geoData, leafletReady, tripSegmentsGeometry, activeTab, mapZoom, pins, editingPin, pinMode, railwayData
     } = useStore(useShallow(state => ({
         geoData: state.geoData,
         leafletReady: state.leafletReady,
         tripSegmentsGeometry: state.tripSegmentsGeometry,
         activeTab: state.activeTab,
         mapZoom: state.mapZoom,
-        setMapZoom: state.setMapZoom,
-        setLeafletReady: state.setLeafletReady,
         pins: state.pins,
         editingPin: state.editingPin,
         pinMode: state.pinMode,
-        railwayData: state.railwayData,
-        setEditingPin: state.setEditingPin,
-        setPinMode: state.setPinMode
+        railwayData: state.railwayData
     })));
+    const setMapZoom = useStore(state => state.setMapZoom);
+    const setLeafletReady = useStore(state => state.setLeafletReady);
+    const setEditingPin = useStore(state => state.setEditingPin);
+    const setPinMode = useStore(state => state.setPinMode);
 
     useEffect(() => {
         setLeafletReady(true);


### PR DESCRIPTION
This PR cleans up Zustand store subscriptions by removing stable action setters from `useShallow` mappings. By strictly separating state data consumption from action functions (which have stable references), we prevent unneeded shallow comparisons and potential render loops, enforcing structural cleanliness while changing as little functional logic as possible.

Changes made:
- Updated `AppLayout.tsx`
- Updated `MapContainer.tsx`
- Updated `FabButton.tsx`
- Updated `BottomNav.tsx`

---
*PR created automatically by Jules for task [386890691088588803](https://jules.google.com/task/386890691088588803) started by @OsakaLOOP*