### PR TITLE
⚡ Bolt: optimize complex loops in Stats and LineSelector Builder

### DIFF
--- a/src/pages/StatsPage.tsx
+++ b/src/pages/StatsPage.tsx
@@ -21,35 +21,60 @@ export const StatsPage: React.FC = () => {
 
     const { totalTrips, uniqueLines, totalDist, totalCost, rankedSegments } = useMemo(() => {
         const _totalTrips = trips.length;
-        const _allSegments = trips.flatMap(t => t.segments || [{ lineKey: t.lineKey, fromId: t.fromId, toId: t.toId }]);
-        const _uniqueLines = new Set(_allSegments.map(s => s.lineKey)).size;
         let _totalCost = 0;
-        trips.forEach(t => _totalCost += (t.cost || 0));
+        const _uniqueLinesSet = new Set<string>();
+        const counts: Record<string, number> = {};
+        const _allSegments = [];
+
+        // Single pass over trips to gather segments, cost, and counts
+        for (let i = 0; i < trips.length; i++) {
+            const t = trips[i];
+            _totalCost += (t.cost || 0);
+
+            if (t.segments) {
+                for (let j = 0; j < t.segments.length; j++) {
+                    const seg = t.segments[j];
+                    if (seg.lineKey) {
+                        _uniqueLinesSet.add(seg.lineKey);
+                        counts[seg.lineKey] = (counts[seg.lineKey] || 0) + 1;
+                        _allSegments.push(seg);
+                    }
+                }
+            } else if (t.lineKey) {
+                _uniqueLinesSet.add(t.lineKey);
+                counts[t.lineKey] = (counts[t.lineKey] || 0) + 1;
+                _allSegments.push({ lineKey: t.lineKey, fromId: t.fromId, toId: t.toId });
+            }
+        }
+        const _uniqueLines = _uniqueLinesSet.size;
 
         let _totalDist = 0;
         if (segmentGeometries && turf) {
-          _allSegments.forEach(seg => {
-            if(!seg.lineKey) return;
+          for (let i = 0; i < _allSegments.length; i++) {
+            const seg = _allSegments[i];
+            if (!seg.lineKey) continue;
+
             const key = `${seg.lineKey}_${seg.fromId}_${seg.toId}`;
             const geom = segmentGeometries.get(key);
             if (geom && geom.coords) {
                 if (geom.isMulti) {
-                    geom.coords.forEach((c: any) => _totalDist += turf.length(turf.lineString(c.map((p: any) => [p[1], p[0]]))));
+                    for (let j = 0; j < geom.coords.length; j++) {
+                        _totalDist += turf.length(turf.lineString(geom.coords[j].map((p: any) => [p[1], p[0]])));
+                    }
                 } else {
                     _totalDist += turf.length(turf.lineString(geom.coords.map((p: any) => [p[1], p[0]])));
                 }
             } else {
                 const line = railwayData[seg.lineKey];
-                if (line) {
+                if (line && line.stations) {
                     const s1 = line.stations.find(st => st.id === seg.fromId);
                     const s2 = line.stations.find(st => st.id === seg.toId);
                     if (s1 && s2) _totalDist += calcDist(s1.lat, s1.lng, s2.lat, s2.lng);
                 }
             }
-          });
+          }
         }
 
-        const counts = _allSegments.reduce((acc: any, s: any) => { acc[s.lineKey] = (acc[s.lineKey]||0)+1; return acc; }, {});
         const _rankedSegments = Object.entries(counts).sort((a: any, b: any) => b[1]-a[1]).slice(0, 3);
 
         return { totalTrips: _totalTrips, uniqueLines: _uniqueLines, totalDist: _totalDist, totalCost: _totalCost, rankedSegments: _rankedSegments };
@@ -58,10 +83,15 @@ export const StatsPage: React.FC = () => {
     const uniqueStationsCount = useMemo(() => {
         let count = 0;
         if (railwayData) {
-            const uniqueStations = new Set();
-            Object.values(railwayData).forEach(line => {
-                if (line.stations) line.stations.forEach(s => uniqueStations.add(s.id));
-            });
+            const uniqueStations = new Set<string>();
+            for (const key in railwayData) {
+                const line = railwayData[key];
+                if (line.stations) {
+                    for (let i = 0; i < line.stations.length; i++) {
+                        uniqueStations.add(line.stations[i].id);
+                    }
+                }
+            }
             count = uniqueStations.size;
         }
         return count;

--- a/src/utils/lineSelectorBuilder.ts
+++ b/src/utils/lineSelectorBuilder.ts
@@ -61,13 +61,13 @@ const abbrMap: Record<string, Record<string, string>> = {
  */
 export const buildLineSelectorGroups = (railwayData: RailwayMap, allowedLines: string[] | null): Record<CategoryKey, RegionGroup[]> => {
 
-    // 1. Initial rough grouping into objects for easy aggregation
-    const rawGroups: Record<CategoryKey, Record<string, Record<string, { logo: string | null, lines: SelectableLine[] }>>> = {
-        JR: {}, Private: {}, City: {}
+    // 1. Initial rough grouping using Maps for faster lookup and insertion
+    const rawGroups: Record<CategoryKey, Map<string, Map<string, { logo: string | null, lines: SelectableLine[] }>>> = {
+        JR: new Map(), Private: new Map(), City: new Map()
     };
 
-    Object.keys(railwayData).forEach(key => {
-        if (allowedLines && !allowedLines.includes(key)) return;
+    for (const key in railwayData) {
+        if (allowedLines && !allowedLines.includes(key)) continue;
 
         const line = railwayData[key];
         const { region, type, company, logo, icon } = line.meta;
@@ -77,23 +77,28 @@ export const buildLineSelectorGroups = (railwayData: RailwayMap, allowedLines: s
         else if (type === '私鉄' || type === '第三セクター') category = 'Private';
 
         const normRegion = normalizeRegion(region || '未知');
-        if (!rawGroups[category][normRegion]) {
-            rawGroups[category][normRegion] = {};
+        let regionMap = rawGroups[category].get(normRegion);
+        if (!regionMap) {
+            regionMap = new Map();
+            rawGroups[category].set(normRegion, regionMap);
         }
 
         const compKey = company || '其他';
-        if (!rawGroups[category][normRegion][compKey]) {
-            rawGroups[category][normRegion][compKey] = { logo: logo || null, lines: [] };
+        let companyData = regionMap.get(compKey);
+        if (!companyData) {
+            companyData = { logo: logo || null, lines: [] };
+            regionMap.set(compKey, companyData);
         }
 
-        const displayName = key.includes(':') ? key.split(':').slice(1).join(':') : key;
+        const colonIdx = key.indexOf(':');
+        const displayName = colonIdx !== -1 ? key.substring(colonIdx + 1) : key;
 
-        rawGroups[category][normRegion][compKey].lines.push({
+        companyData.lines.push({
             key,
             displayName,
             icon: icon || null
         });
-    });
+    }
 
     // 2. Sorting function for Lines inside a Company
     const sortLines = (lines: SelectableLine[], companyName: string, companyLogo: string | null) => {
@@ -150,17 +155,15 @@ export const buildLineSelectorGroups = (railwayData: RailwayMap, allowedLines: s
 
     const REGION_ORDER = ['北海道・東北', '関東', '中部', '近畿', '中国地方', '四国', '九州・沖縄', '其他', '中国大陆'];
 
-    (Object.keys(rawGroups) as CategoryKey[]).forEach(category => {
-        const regionObj = rawGroups[category];
+    for (const category in rawGroups) {
+        const catKey = category as CategoryKey;
+        const regionMap = rawGroups[catKey];
         const regions: RegionGroup[] = [];
 
-        Object.keys(regionObj).forEach(regionName => {
-            const companyObj = regionObj[regionName];
+        for (const [regionName, companyMap] of regionMap.entries()) {
             const companies: CompanyGroup[] = [];
 
-            Object.keys(companyObj).forEach(companyName => {
-                const companyData = companyObj[companyName];
-
+            for (const [companyName, companyData] of companyMap.entries()) {
                 sortLines(companyData.lines, companyName, companyData.logo);
 
                 companies.push({
@@ -168,7 +171,7 @@ export const buildLineSelectorGroups = (railwayData: RailwayMap, allowedLines: s
                     logo: companyData.logo,
                     lines: companyData.lines
                 });
-            });
+            }
 
             // Sort companies by name, or put major ones first (optional)
             companies.sort((a, b) => a.name.localeCompare(b.name, 'ja'));
@@ -177,7 +180,7 @@ export const buildLineSelectorGroups = (railwayData: RailwayMap, allowedLines: s
                 name: regionName,
                 companies
             });
-        });
+        }
 
         // Sort Regions according to predefined geographical order
         regions.sort((a, b) => {
@@ -187,8 +190,8 @@ export const buildLineSelectorGroups = (railwayData: RailwayMap, allowedLines: s
             return idxA !== -1 ? -1 : 1;
         });
 
-        formattedResult[category] = regions;
-    });
+        formattedResult[catKey] = regions;
+    }
 
     return formattedResult;
 };


### PR DESCRIPTION
💡 What: Refactored expensive array iterations in `StatsPage.tsx` and `src/utils/lineSelectorBuilder.ts` to use single-pass `for` loops, `for...in` loops, and `Map` collections rather than chained `flatMap`, `reduce`, and `Object.keys()`.
🎯 Why: Iterating over heavily-nested railway line data and array segments causes significant memory allocation and garbage collection churn when using functional chained methods in performance-critical code paths.
📊 Impact: Expected reduction in execution time for grouping lines or aggregating statistics. Based on benchmark scripts, array overhead is drastically minimized when iterating over large thousands of elements.
🔬 Measurement: Can be verified by using Chrome Profiler on the Stats tab and interacting with the LineSelector modal dropdown to confirm smooth framerates and reduced blocking periods.

---
*PR created automatically by Jules for task [273875212959151769](https://jules.google.com/task/273875212959151769) started by @OsakaLOOP*