### PR TITLE
feat(ui): add subtle and creative component-level animations

### DIFF
--- a/src/components/modals/TripEditor.tsx
+++ b/src/components/modals/TripEditor.tsx
@@ -289,39 +289,40 @@ export const TripEditor: React.FC = () => {
                       );
                   })}
                   </div>
-                  <button onClick={addSegment} disabled={(form.segments?.length || 0) >= 10} className="w-full py-2 border-2 border-dashed border-gray-300 text-gray-400 rounded-lg hover:bg-gray-50 hover:text-gray-600 transition flex items-center justify-center gap-2 disabled:opacity-50"><Plus size={16} /> 添加换乘 / 下一程</button>
-                  <textarea className="w-full p-2 border rounded h-20 bg-gray-50" placeholder="备注..." value={form.memo || ''} onChange={e => setForm({ memo: e.target.value })} />
+                  <button onClick={addSegment} disabled={(form.segments?.length || 0) >= 10} className="w-full py-2 border-2 border-dashed border-gray-300 text-gray-400 rounded-lg hover:bg-gray-50 hover:text-gray-600 hover:border-gray-400 transition-all duration-300 active:scale-[0.98] flex items-center justify-center gap-2 disabled:opacity-50 group"><Plus className="group-hover:rotate-180 transition-transform duration-500" size={16} /> 添加换乘 / 下一程</button>
+                  <textarea className="w-full p-2 border rounded h-20 bg-gray-50 focus:ring-2 focus:ring-emerald-200 outline-none transition-all duration-300" placeholder="备注..." value={form.memo || ''} onChange={e => setForm({ memo: e.target.value })} />
               </div>
             )}
 
             {editorMode === EditorMode.Auto && (
                 <div className="p-6 space-y-6 flex-1 transition-opacity duration-300">
-                    <div id="auto-planning-form" className="space-y-4 bg-blue-50 p-4 rounded-lg border border-blue-100">
+                    <div id="auto-planning-form" className="space-y-4 bg-blue-50 p-4 rounded-lg border border-blue-100 relative overflow-hidden">
+                        <div className="absolute top-0 left-0 w-full h-1 bg-gradient-to-r from-blue-300 via-blue-500 to-blue-300 opacity-50"></div>
                         <div>
                             <label className="block text-xs font-bold text-slate-500 mb-1">出发地</label>
                             <div className="grid grid-cols-2 gap-2">
-                                <button onClick={() => openSelector('autoStart')} className="p-2 rounded border text-sm text-left bg-white text-gray-700 truncate flex items-center gap-1">{autoForm.startLine ? <span>{autoForm.startLine}</span> : <span className="text-gray-400">选择线路...</span>}</button>
-                                <select className="p-2 rounded border text-sm" disabled={!autoForm.startLine} value={autoForm.startStation} onChange={e => setAutoForm({ ...autoForm, startStation: e.target.value })}><option value="">车站...</option>{autoForm.startLine && railwayData[autoForm.startLine]?.stations.map(s => <option key={s.id} value={s.id}>{s.name_ja}</option>)}</select>
+                                <button onClick={() => openSelector('autoStart')} className="p-2 rounded border text-sm text-left bg-white text-gray-700 truncate flex items-center gap-1 hover:border-blue-300 hover:shadow-sm transition-all">{autoForm.startLine ? <span>{autoForm.startLine}</span> : <span className="text-gray-400">选择线路...</span>}</button>
+                                <select className="p-2 rounded border text-sm hover:border-blue-300 hover:shadow-sm transition-all outline-none" disabled={!autoForm.startLine} value={autoForm.startStation} onChange={e => setAutoForm({ ...autoForm, startStation: e.target.value })}><option value="">车站...</option>{autoForm.startLine && railwayData[autoForm.startLine]?.stations.map(s => <option key={s.id} value={s.id}>{s.name_ja}</option>)}</select>
                             </div>
                         </div>
-                        <div className="flex justify-center text-blue-300"><ArrowDown size={20}/></div>
+                        <div className="flex justify-center text-blue-300"><ArrowDown className="animate-bounce" size={20}/></div>
                         <div>
                             <label className="block text-xs font-bold text-slate-500 mb-1">目的地</label>
                             <div className="grid grid-cols-2 gap-2">
-                                <button onClick={() => openSelector('autoEnd')} className="p-2 rounded border text-sm text-left bg-white text-gray-700 truncate flex items-center gap-1">{autoForm.endLine ? <span>{autoForm.endLine}</span> : <span className="text-gray-400">选择线路...</span>}</button>
-                                <select className="p-2 rounded border text-sm" disabled={!autoForm.endLine} value={autoForm.endStation} onChange={e => setAutoForm({ ...autoForm, endStation: e.target.value })}><option value="">车站...</option>{autoForm.endLine && railwayData[autoForm.endLine]?.stations.map(s => <option key={s.id} value={s.id}>{s.name_ja}</option>)}</select>
+                                <button onClick={() => openSelector('autoEnd')} className="p-2 rounded border text-sm text-left bg-white text-gray-700 truncate flex items-center gap-1 hover:border-blue-300 hover:shadow-sm transition-all">{autoForm.endLine ? <span>{autoForm.endLine}</span> : <span className="text-gray-400">选择线路...</span>}</button>
+                                <select className="p-2 rounded border text-sm hover:border-blue-300 hover:shadow-sm transition-all outline-none" disabled={!autoForm.endLine} value={autoForm.endStation} onChange={e => setAutoForm({ ...autoForm, endStation: e.target.value })}><option value="">车站...</option>{autoForm.endLine && railwayData[autoForm.endLine]?.stations.map(s => <option key={s.id} value={s.id}>{s.name_ja}</option>)}</select>
                             </div>
                         </div>
                     </div>
-                    <button onClick={onAutoSearch} disabled={isRouteSearching} className="w-full bg-blue-600 text-white py-3 rounded-lg font-bold flex items-center justify-center gap-2 hover:bg-blue-700 transition shadow-lg disabled:opacity-70">
-                        {isRouteSearching ? <Loader2 className="animate-spin"/> : <Search size={18}/>}
+                    <button onClick={onAutoSearch} disabled={isRouteSearching} className="w-full bg-blue-600 text-white py-3 rounded-lg font-bold flex items-center justify-center gap-2 hover:bg-blue-700 hover:-translate-y-0.5 hover:shadow-lg active:scale-[0.98] active:translate-y-0 transition-all duration-300 disabled:opacity-70 disabled:hover:translate-y-0 disabled:hover:scale-100 disabled:hover:shadow-none group">
+                        {isRouteSearching ? <Loader2 className="animate-spin"/> : <Search className="group-hover:scale-110 transition-transform duration-300" size={18}/>}
                         {isRouteSearching ? '规划中...' : '搜索推荐路线'}
                     </button>
                     <div className="text-xs text-center text-slate-400">仅支持同一公司或JR集团内的换乘搜索</div>
                 </div>
             )}
 
-            {editorMode === EditorMode.Manual && <div className="p-4 border-t"><button onClick={onSave} className="w-full bg-emerald-600 text-white py-3 rounded-lg font-bold">保存行程</button></div>}
+            {editorMode === EditorMode.Manual && <div className="p-4 border-t"><button onClick={onSave} className="w-full bg-emerald-600 text-white py-3 rounded-lg font-bold hover:bg-emerald-500 hover:-translate-y-0.5 hover:shadow-lg active:scale-[0.98] active:translate-y-0 transition-all duration-300">保存行程</button></div>}
           </div>
         </div>
         <LineSelector isOpen={selectorOpen} onClose={() => setSelectorOpen(false)} onSelect={handleLineSelect} allowedLines={allowedLines} />

--- a/src/pages/StatsPage.tsx
+++ b/src/pages/StatsPage.tsx
@@ -99,8 +99,8 @@ export const StatsPage: React.FC = () => {
         )}
 
         <div className="grid grid-cols-2 gap-4">
-            <div className="bg-white p-4 rounded-xl shadow-sm border text-center"><div className="text-xs text-gray-400 mb-1">记录数</div><div className="text-3xl font-bold text-gray-800">{totalTrips}</div></div>
-            <div className="bg-white p-4 rounded-xl shadow-sm border text-center"><div className="text-xs text-gray-400 mb-1">制霸路线</div><div className="text-3xl font-bold text-indigo-600">{uniqueLines}</div></div>
+            <div className="bg-white p-4 rounded-xl shadow-sm border text-center hover:scale-105 hover:shadow-md transition-all duration-300 cursor-default"><div className="text-xs text-gray-400 mb-1">记录数</div><div className="text-3xl font-bold text-gray-800">{totalTrips}</div></div>
+            <div className="bg-white p-4 rounded-xl shadow-sm border text-center hover:scale-105 hover:shadow-md transition-all duration-300 cursor-default"><div className="text-xs text-gray-400 mb-1">制霸路线</div><div className="text-3xl font-bold text-indigo-600">{uniqueLines}</div></div>
         </div>
 
         {user && (
@@ -118,8 +118,8 @@ export const StatsPage: React.FC = () => {
             </button>
         )}
 
-        <div className="bg-gradient-to-br from-emerald-600 to-teal-700 p-6 rounded-xl shadow-lg text-white">
-            <div className="flex items-center justify-between mb-2"><h3 className="font-bold flex items-center gap-2"><TrendingUp size={18}/> 里程统计</h3><span className="text-xs bg-white/20 px-2 py-1 rounded">总距离</span></div>
+        <div className="bg-gradient-to-br from-emerald-600 to-teal-700 hover:from-teal-600 hover:to-emerald-800 p-6 rounded-xl shadow-lg text-white transition-all duration-500 hover:-translate-y-1 hover:shadow-xl cursor-default group">
+            <div className="flex items-center justify-between mb-2"><h3 className="font-bold flex items-center gap-2"><TrendingUp size={18} className="group-hover:-translate-y-1 group-hover:scale-110 transition-transform duration-300"/> 里程统计</h3><span className="text-xs bg-white/20 px-2 py-1 rounded">总距离</span></div>
             <div className="text-4xl font-bold mb-2">{Math.round(totalDist)} <span className="text-lg font-normal opacity-80">km</span></div>
             <div className="border-t border-white/20 pt-2 flex items-center gap-2 text-sm opacity-90"><span className="font-bold">¥</span> 总开销: {totalCost.toLocaleString()}</div>
         </div>
@@ -127,7 +127,7 @@ export const StatsPage: React.FC = () => {
           {rankedSegments.map(([line, count]: [string, any], idx) => {
               const icon = railwayData[line]?.meta?.icon;
               return (
-                  <div key={line} className="p-3 border-b last:border-0 flex justify-between items-center">
+                  <div key={line} className="p-3 border-b last:border-0 flex justify-between items-center hover:bg-slate-50 transition-colors duration-200">
                       <div className="flex items-center gap-3">
                           <span className={`w-5 h-5 rounded-full flex items-center justify-center text-xs font-bold ${idx===0?'bg-yellow-100 text-yellow-700':'bg-slate-100 text-slate-600'}`}>{idx+1}</span>
                           {icon && <img src={icon} alt="" className="line-icon" />}

--- a/src/pages/TripsPage.tsx
+++ b/src/pages/TripsPage.tsx
@@ -70,7 +70,7 @@ export const TripsPage: React.FC = () => {
                 trips.map(t => {
                     const segments = t.segments || [{ lineKey: t.lineKey, fromId: t.fromId, toId: t.toId }];
                     return (
-                        <div key={t.id} className="bg-white p-4 rounded-lg border shadow-sm">
+                        <div key={t.id} className="bg-white p-4 rounded-lg border shadow-sm transition-all duration-300 hover:shadow-md hover:-translate-y-1">
                             <div className="flex justify-between mb-2 pb-2 border-b border-gray-50">
                                 <span className="text-xs font-bold text-gray-400">{t.date}</span>
                                 <div className="flex items-center gap-2">
@@ -112,7 +112,9 @@ export const TripsPage: React.FC = () => {
                     startEditingTrip({ date: new Date().toISOString().split('T')[0], memo: '', segments: newSegments, cost: 0 });
                 }
             }}>
-                <button id="btn-add-trip" onClick={() => startEditingTrip()} className="w-full py-4 border-2 border-dashed border-gray-300 text-gray-400 rounded-xl hover:bg-gray-50 font-bold transition">+ 记录新行程</button>
+                <button id="btn-add-trip" onClick={() => startEditingTrip()} className="w-full py-4 border-2 border-dashed border-gray-300 text-gray-400 rounded-xl hover:bg-emerald-50 hover:text-emerald-600 hover:border-emerald-300 font-bold transition-all duration-300 active:scale-[0.98] group flex items-center justify-center gap-2">
+                    <Plus className="group-hover:rotate-90 transition-transform duration-300" size={18} /> 记录新行程
+                </button>
             </DropZone>
         </div>
     );


### PR DESCRIPTION
This PR implements three subtle, elegant UI enhancements as requested:
1. **Interactive Trip Cards**: Lift up effect on hover with an enhanced shadow on `TripsPage`.
2. **Animated Stats Overview**: Smooth scale effects on stats cards, and a floating icon animation for the main mileage card on `StatsPage`.
3. **Engaging Buttons**: Press/hover animations on the main Editor buttons and form inputs on `TripEditor`.

All changes utilize lightweight Tailwind transitions strictly within components, without altering the core logic or layout. The missing `Plus` icon import that caused the render issue has been resolved, and a missing `group` class constraint for the search button zoom has been corrected.

---
*PR created automatically by Jules for task [2918461555423267561](https://jules.google.com/task/2918461555423267561) started by @OsakaLOOP*