### PR TITLE
Fix RailwayLineMeta missing company field

### DIFF
--- a/src/RailRound.jsx
+++ b/src/RailRound.jsx
@@ -1982,8 +1982,8 @@ function RailLOOPContent() {
              const compName = line.meta.company;
              if (companyDB[compName]) {
                  const info = companyDB[compName];
-                 if(!line.meta.region ||!line.meta.type ||line.meta.region === "未知" || line.meta.type === "未知") {
-                     next[lineKey] = { ...line, meta: { ...line.meta, region: info.region, type: info.type, logo: info.logo } };
+                 if(!line.meta.region ||!line.meta.type ||line.meta.region === "未知" || line.meta.type === "未知" || !line.meta.company) {
+                     next[lineKey] = { ...line, meta: { ...line.meta, company: compName || "未知", region: info.region, type: info.type, logo: info.logo } };
                      changed = true;
                  }
              }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -86,6 +86,7 @@ export interface Station {
 }
 
 export interface RailwayLineMeta extends CompanyMeta {
+  company: string;
   icon?: URLString | null;
 }
 


### PR DESCRIPTION
Added `company: string` field to `RailwayLineMeta` in `src/store/index.ts` to reflect the expected data shape and fix "Property 'company' does not exist on type 'RailwayLineMeta'" issues downstream. Adjusted data parsing fallbacks in `RailRound.jsx` to ensure `meta: { ... }` object spreading respects the newly enforced required `company` type constraint during runtime data updates.

---
*PR created automatically by Jules for task [12029243676183265670](https://jules.google.com/task/12029243676183265670) started by @OsakaLOOP*