### PR TITLE
Fix Leaflet station rendering identity and z-index overlap

### DIFF
--- a/src/components/map/MapContainer.tsx
+++ b/src/components/map/MapContainer.tsx
@@ -135,8 +135,14 @@ export const MapContainer: React.FC<Props> = ({ setStationMenu, isDraggingRef })
         dark.addTo(map); rail.addTo(map);
         L.control.layers({ "标准 (light)": light, "暗色 (Dark)": dark }, { "详细配线图 (OpenRailwayMap)": rail }, { position: 'topright' }).addTo(map);
 
-        map.createPane('stationPane');
-        map.getPane('stationPane')!.style.zIndex = '450'; // overlayPane is 400, markerPane is 600
+        map.createPane('baseLinesPane');
+        map.getPane('baseLinesPane')!.style.zIndex = '390';
+        map.createPane('baseStationsPane');
+        map.getPane('baseStationsPane')!.style.zIndex = '400';
+        map.createPane('routePane');
+        map.getPane('routePane')!.style.zIndex = '410';
+        map.createPane('visitedStationsPane');
+        map.getPane('visitedStationsPane')!.style.zIndex = '420';
 
         mapInstance.current = map;
 
@@ -449,7 +455,7 @@ export const MapContainer: React.FC<Props> = ({ setStationMenu, isDraggingRef })
                     fillOpacity: isVisited ? 1.0 : 0.5,
                     weight: isVisited ? 2 : 0,
                     className: 'station-dot',
-                    pane: 'stationPane'
+                    pane: isVisited ? 'visitedStationsPane' : 'baseStationsPane'
                 });
                 // @ts-ignore
                 layer._cachedIsVisited = isVisited;
@@ -569,6 +575,16 @@ export const MapContainer: React.FC<Props> = ({ setStationMenu, isDraggingRef })
                         fillOpacity: isVisited ? 1.0 : 0.5,
                         weight: isVisited ? 2 : 0
                     });
+
+                    // Changing panes in Leaflet requires removing and re-adding the layer to its parent layer group.
+                    if (marker.options.pane !== (isVisited ? 'visitedStationsPane' : 'baseStationsPane')) {
+                        marker.options.pane = isVisited ? 'visitedStationsPane' : 'baseStationsPane';
+                        if (baseStationsLayer.current && baseStationsLayer.current.hasLayer(marker)) {
+                            baseStationsLayer.current.removeLayer(marker);
+                            baseStationsLayer.current.addLayer(marker);
+                        }
+                    }
+
                     marker._cachedIsVisited = isVisited;
                     changed = true;
                 }
@@ -587,6 +603,7 @@ export const MapContainer: React.FC<Props> = ({ setStationMenu, isDraggingRef })
         const lineFeatures = data.features.filter((f: CustomGeoJSONFeature) => f.geometry.type === 'LineString' || f.geometry.type === 'MultiLineString');
         L.geoJSON(lineFeatures as any, {
             style: { color: '#475569', weight: 1, opacity: 0.3 },
+            pane: 'baseLinesPane',
             interactive: false
         }).addTo(baseLinesLayer.current);
     };
@@ -615,7 +632,7 @@ export const MapContainer: React.FC<Props> = ({ setStationMenu, isDraggingRef })
             routeItems,
             (item) => item.id,
             (item) => {
-                const options = { color: item.color, weight: zoomWeight, opacity: 0.9, lineCap: 'round', smoothFactor: 0.2, dashArray: item.fallback ? '5, 10' : undefined };
+                const options = { color: item.color, weight: zoomWeight, opacity: 0.9, lineCap: 'round', smoothFactor: 0.2, dashArray: item.fallback ? '5, 10' : undefined, pane: 'routePane' };
                 const pl = L.polyline(item.coords, options as L.PolylineOptions).bindPopup(item.popup);
                 (pl as any)._cachedCoords = item.coords;
                 return pl;

--- a/src/components/map/MapContainer.tsx
+++ b/src/components/map/MapContainer.tsx
@@ -134,6 +134,10 @@ export const MapContainer: React.FC<Props> = ({ setStationMenu, isDraggingRef })
 
         dark.addTo(map); rail.addTo(map);
         L.control.layers({ "标准 (light)": light, "暗色 (Dark)": dark }, { "详细配线图 (OpenRailwayMap)": rail }, { position: 'topright' }).addTo(map);
+
+        map.createPane('stationPane');
+        map.getPane('stationPane')!.style.zIndex = '450'; // overlayPane is 400, markerPane is 600
+
         mapInstance.current = map;
 
         baseLinesLayer.current = L.layerGroup();
@@ -435,7 +439,8 @@ export const MapContainer: React.FC<Props> = ({ setStationMenu, isDraggingRef })
             (f) => f.properties.id || `${f.properties.company}:${f.properties.line}:${f.properties.name}`,
             (f) => {
                 const latlng = [f.geometry.coordinates[1], f.geometry.coordinates[0]] as [number, number];
-                const isVisited = visitedStationsRef.current.has(f.properties.id || '');
+                const stationId = f.properties.id || `${f.properties.company}:${f.properties.line}:${f.properties.name}`;
+                const isVisited = visitedStationsRef.current.has(stationId);
                 const lineColor = f.properties.stroke || '#64748b'; // Fallback if no stroke defined
                 const layer = L.circleMarker(latlng, {
                     radius: isVisited ? 5 : 4,
@@ -443,7 +448,8 @@ export const MapContainer: React.FC<Props> = ({ setStationMenu, isDraggingRef })
                     fillColor: isVisited ? lineColor : '#64748b',
                     fillOpacity: isVisited ? 1.0 : 0.5,
                     weight: isVisited ? 2 : 0,
-                    className: 'station-dot'
+                    className: 'station-dot',
+                    pane: 'stationPane'
                 });
                 // @ts-ignore
                 layer._cachedIsVisited = isVisited;
@@ -533,7 +539,8 @@ export const MapContainer: React.FC<Props> = ({ setStationMenu, isDraggingRef })
             },
             (layer, f) => {
                 const marker = layer as any;
-                const isVisited = visitedStationsRef.current.has(f.properties.id || '');
+                const stationId = f.properties.id || `${f.properties.company}:${f.properties.line}:${f.properties.name}`;
+                const isVisited = visitedStationsRef.current.has(stationId);
                 const lineColor = f.properties.stroke || '#64748b';
                 const newLat = f.geometry.coordinates[1];
                 const newLng = f.geometry.coordinates[0];


### PR DESCRIPTION
Fixes the Leaflet map rendering where visited station dots were missing due to missing IDs in GeoJSON features and were being incorrectly obscured by the visited route paths due to default z-index overlap.

---
*PR created automatically by Jules for task [12683703002930771778](https://jules.google.com/task/12683703002930771778) started by @OsakaLOOP*