### PR TITLE
feat: auto-route infinite search retry on transfer limit exceeded

### DIFF
--- a/src/RailRound.jsx
+++ b/src/RailRound.jsx
@@ -860,7 +860,7 @@ const TripEditor = ({
                     </div>
                 </div>
             </div>
-            <button onClick={onAutoSearch} disabled={isRouteSearching} className="w-full bg-blue-600 text-white py-3 rounded-lg font-bold flex items-center justify-center gap-2 hover:bg-blue-700 transition shadow-lg disabled:opacity-70">
+            <button onClick={() => onAutoSearch(false)} disabled={isRouteSearching} className="w-full bg-blue-600 text-white py-3 rounded-lg font-bold flex items-center justify-center gap-2 hover:bg-blue-700 transition shadow-lg disabled:opacity-70">
                 {isRouteSearching ? <Loader2 className="animate-spin"/> : <Search size={18}/>}
                 {isRouteSearching ? '规划中...' : '搜索推荐路线'}
             </button>
@@ -2342,13 +2342,28 @@ function RailLOOPContent() {
       }
   };
   
-  const handleAutoRouteSearch = () => {
+  const handleAutoRouteSearch = (retryWithInfiniteSearch = false) => {
+    const isInfinite = retryWithInfiniteSearch === true;
     const { startLine, startStation, endLine, endStation } = autoForm;
     if(!startLine || !startStation || !endLine || !endStation) return;
     setIsRouteSearching(true);
     setTimeout(() => {
-        const result = findRoute(startLine, startStation, endLine, endStation, railwayData);
-        if (result.error) { setIsRouteSearching(false); alert(`无法规划: ${result.error}`); } 
+        const result = findRoute(startLine, startStation, endLine, endStation, railwayData, isInfinite ? -1 : 6);
+        if (result.error) {
+            setIsRouteSearching(false);
+            if (!isInfinite && result.error.includes("超出最大换乘次数")) {
+                setTimeout(() => {
+                    const wantRetry = window.confirm("自动规划超出6次换乘限制或无解。\n是否继续无限制深度搜索？(这可能需要较长等待时间)");
+                    if (wantRetry) {
+                        handleAutoRouteSearch(true);
+                    }
+                }, 100);
+            } else {
+                setTimeout(() => {
+                    alert(`无法规划: ${result.error}`);
+                }, 100);
+            }
+        }
         else { 
             if(result.segments.length > 20) { setIsRouteSearching(false); alert("路径过长"); return; } 
             setTripForm(prev => ({ ...prev, segments: result.segments })); setEditorMode('manual'); 

--- a/src/components/modals/TripEditor.tsx
+++ b/src/components/modals/TripEditor.tsx
@@ -81,13 +81,35 @@ export const TripEditor: React.FC = () => {
         closeEditor();
     };
 
-    const onAutoSearch = () => {
+    const onAutoSearch = (retryWithInfiniteSearch = false) => {
+        const isInfinite = retryWithInfiniteSearch === true;
         const { startLine, startStation, endLine, endStation } = autoForm;
         if(!startLine || !startStation || !endLine || !endStation) return;
         setIsRouteSearching(true);
         setTimeout(() => {
-            const result = findRoute(startLine, startStation, endLine, endStation, railwayData);
-            if (result.error) { setIsRouteSearching(false); alert(`无法规划: ${result.error}`); }
+            const result = findRoute(
+                startLine,
+                startStation,
+                endLine,
+                endStation,
+                railwayData,
+                isInfinite ? -1 : 6
+            );
+            if (result.error) {
+                setIsRouteSearching(false);
+                if (!isInfinite && result.error.includes("超出最大换乘次数")) {
+                    setTimeout(() => {
+                        const wantRetry = window.confirm("自动规划超出6次换乘限制或无解。\n是否继续无限制深度搜索？(这可能需要较长等待时间)");
+                        if (wantRetry) {
+                            onAutoSearch(true);
+                        }
+                    }, 100);
+                } else {
+                    setTimeout(() => {
+                        alert(`无法规划: ${result.error}`);
+                    }, 100);
+                }
+            }
             else {
                 if(result.segments.length > 20) { setIsRouteSearching(false); alert("路径过长"); return; }
                 setForm({ segments: result.segments });
@@ -367,7 +389,7 @@ export const TripEditor: React.FC = () => {
                             </div>
                         </div>
                     </div>
-                    <button onClick={onAutoSearch} disabled={isRouteSearching} className="w-full bg-blue-600 text-white py-3 rounded-lg font-bold flex items-center justify-center gap-2 hover:bg-blue-700 hover:-translate-y-0.5 hover:shadow-lg active:scale-[0.98] active:translate-y-0 transition-all duration-300 disabled:opacity-70 disabled:hover:translate-y-0 disabled:hover:scale-100 disabled:hover:shadow-none group">
+                    <button onClick={() => onAutoSearch(false)} disabled={isRouteSearching} className="w-full bg-blue-600 text-white py-3 rounded-lg font-bold flex items-center justify-center gap-2 hover:bg-blue-700 hover:-translate-y-0.5 hover:shadow-lg active:scale-[0.98] active:translate-y-0 transition-all duration-300 disabled:opacity-70 disabled:hover:translate-y-0 disabled:hover:scale-100 disabled:hover:shadow-none group">
                         {isRouteSearching ? <Loader2 className="animate-spin"/> : <Search className="group-hover:scale-110 transition-transform duration-300" size={18}/>}
                         {isRouteSearching ? '规划中...' : '搜索推荐路线'}
                     </button>

--- a/src/utils/railwayRouting.ts
+++ b/src/utils/railwayRouting.ts
@@ -72,7 +72,7 @@ interface RouteNode {
     parent: RouteNode | null;
 }
 
-export const findRoute = (startLineKey: string, startStId: string, endLineKey: string, endStId: string, railwayData: RailwayMap) => {
+export const findRoute = (startLineKey: string, startStId: string, endLineKey: string, endStId: string, railwayData: RailwayMap, maxTransfersOverride?: number) => {
     if (!startLineKey || !endLineKey) return { error: "无效的起点或终点" };
 
     const startLine = railwayData[startLineKey];
@@ -113,7 +113,7 @@ export const findRoute = (startLineKey: string, startStId: string, endLineKey: s
 
     openSet.push(startNode);
 
-    const MAX_TRANSFERS = 6;
+    const MAX_TRANSFERS = maxTransfersOverride !== undefined ? maxTransfersOverride : 6;
     let bestEndNode: RouteNode | null = null;
 
     // Helper: Push and sort (simulated priority queue)
@@ -150,7 +150,7 @@ export const findRoute = (startLineKey: string, startStId: string, endLineKey: s
             break;
         }
 
-        if (current.transfers >= MAX_TRANSFERS) continue;
+        if (MAX_TRANSFERS >= 0 && current.transfers >= MAX_TRANSFERS) continue;
 
         // 1. Move Forward / Backward on the CURRENT line
         const speed = getSpeed(current.lineKey);


### PR DESCRIPTION
This PR adds a safety net/retry feature for the auto route planning system. Previously, the system strictly aborted and threw an error when the path required more than 6 transfers. Now, when this limit is hit, the application will display a prompt asking the user if they would like to attempt a longer, unbounded depth search to find a connection, which could potentially take longer but ensures a path is found if one exists.

---
*PR created automatically by Jules for task [7501915668832448723](https://jules.google.com/task/7501915668832448723) started by @OsakaLOOP*