### PR TITLE
Optimize and separate leaflet station unmounting logic

### DIFF
--- a/src/components/map/MapContainer.tsx
+++ b/src/components/map/MapContainer.tsx
@@ -166,6 +166,16 @@ export const MapContainer: React.FC<Props> = ({ setStationMenu, isDraggingRef })
                      if (map.hasLayer(baseLinesLayer.current)) map.removeLayer(baseLinesLayer.current);
                 }
             }
+
+            const baseStationsPane = map.getPane('baseStationsPane');
+            if (baseStationsPane) {
+                baseStationsPane.style.display = z < 5 ? 'none' : '';
+            }
+            const visitedStationsPane = map.getPane('visitedStationsPane');
+            if (visitedStationsPane) {
+                visitedStationsPane.style.display = z <= 6 ? 'none' : '';
+            }
+
             setMapZoom(z);
         };
 


### PR DESCRIPTION
Separated the unloading/visibility threshold of visited stations (`zoom <= 6`) from unvisited stations (`zoom < 5`) on the map by dynamically toggling the display property of their respective Leaflet Panes (`visitedStationsPane` and `baseStationsPane`). This bulk approach prevents computationally expensive iterative filtering inside `syncLeafletLayerGroup`.

---
*PR created automatically by Jules for task [6710659108838080447](https://jules.google.com/task/6710659108838080447) started by @OsakaLOOP*