### PR TITLE
feat: Configure EdgeOne Cache-Control and asset versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ dist.rar
 public/assets/company_logos/*
 *.py
 *.bak
+!edgeone.json

--- a/edgeone.json
+++ b/edgeone.json
@@ -1,0 +1,31 @@
+{
+  "headers": [
+    {
+      "source": "/*",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "max-age=86400"
+        }
+      ]
+    },
+    {
+      "source": "/",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-cache, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/index.html",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-cache, must-revalidate"
+        }
+      ]
+    }
+  ]
+}

--- a/src/AppLayout.tsx
+++ b/src/AppLayout.tsx
@@ -301,7 +301,7 @@ export const AppLayout: React.FC = () => {
             { id: toastId, duration: Infinity }
         );
             try {
-                const companyRes = await fetch('/company_data.json');
+                const companyRes = await fetch(`/company_data.json?v=${CURRENT_VERSION}`);
                 if (companyRes.ok) {
                     const txt = await companyRes.text();
                     currentCompanyData = normalizeCompanyDataLogos(JSON.parse(txt.replace(/^\uFEFF/, '')));
@@ -518,7 +518,7 @@ export const AppLayout: React.FC = () => {
             ),
             { id: toastId, duration: Infinity }
         );
-            const manifestRes = await fetch('/geojson_manifest.json').catch(() => null);
+            const manifestRes = await fetch(`/geojson_manifest.json?v=${CURRENT_VERSION}`).catch(() => null);
             if (manifestRes && manifestRes.ok) {
                 const manifest = await manifestRes.json();
                 const geojsonFiles = manifest.files || [];
@@ -531,7 +531,7 @@ export const AppLayout: React.FC = () => {
                     const totalToDownload = missingFiles.length;
                     const downloadTasks = missingFiles.map(async (fileName: string) => {
                         try {
-                            const res = await fetch(`/geojson/${fileName.includes('.geojson') ? fileName : `${fileName}.geojson`}`);
+                            const res = await fetch(`/geojson/${fileName.includes('.geojson') ? fileName : `${fileName}.geojson`}?v=${CURRENT_VERSION}`);
                             downloadedCount++;
                             const progress = 30 + Math.round((downloadedCount / totalToDownload) * 20); // Scale up to 50%
                             toast.loading(

--- a/src/RailRound.jsx
+++ b/src/RailRound.jsx
@@ -1733,7 +1733,7 @@ function RailLOOPContent() {
       // 1. 先加载基础元数据 (Company DB)
       let currentCompanyData = {};
       try {
-        const companyRes = await fetch('/company_data.json');
+        const companyRes = await fetch(`/company_data.json?v=${CURRENT_VERSION}`);
         if (companyRes.ok) {
           const txt = await companyRes.text();
           // 处理 BOM 头并解析
@@ -1842,7 +1842,7 @@ function RailLOOPContent() {
       }
 
       // 3. Network Fetch (Background Update)
-      const manifestRes = await fetch('/geojson_manifest.json').catch(() => null);
+      const manifestRes = await fetch(`/geojson_manifest.json?v=${CURRENT_VERSION}`).catch(() => null);
       if (!manifestRes || !manifestRes.ok) {
           console.warn('[Autoload] 无法获取 manifest, 跳过更新检查');
           return;
@@ -1873,7 +1873,7 @@ function RailLOOPContent() {
       const downloadTasks = missingFiles.map(async (fileName) => {
         try {
           const fileNameWithExt = fileName.includes('.geojson') ? fileName : `${fileName}.geojson`;
-          const res = await fetch(`/geojson/${fileNameWithExt}`);
+          const res = await fetch(`/geojson/${fileNameWithExt}?v=${CURRENT_VERSION}`);
           if (!res.ok) throw new Error(`Status ${res.status}`);
           const json = await res.json();
           const rawCompanyName = fileName.replace(/\.(geojson|json)$/i, '');


### PR DESCRIPTION
This PR implements cache-control for static assets by leveraging EdgeOne Pages configuration (`edgeone.json`) and versioned query parameters.

### Changes:
1.  **`edgeone.json`**: Created to define HTTP response headers on Tencent EdgeOne Pages.
    *   `/*`: `Cache-Control: max-age=86400` (caches all assets for 1 day).
    *   `/` and `/index.html`: `Cache-Control: no-cache, must-revalidate` (ensures the entry HTML is never stale, allowing new app versions to load immediately).
2.  **`.gitignore`**: Added `!edgeone.json` to ensure the new configuration file is tracked.
3.  **`AppLayout.tsx` & `RailRound.jsx`**: Updated `fetch` calls for static resources (`company_data.json`, `geojson_manifest.json`, and `.geojson` files) to include a version-based cache buster: `?v=${CURRENT_VERSION}`. This ensures that while the CDN/browser caches these files for 1 day, deploying a new version of the app immediately busts the cache for these resources.
4.  **`VersionBadge.jsx` & `GlobalProvider.jsx` & `LoginModal.jsx`**: Kept timestamp cache-busters (`?t=${Date.now()}`) for `changelog.json` and `readme` files to preserve background polling and update detection.

---
*PR created automatically by Jules for task [568246209300249534](https://jules.google.com/task/568246209300249534) started by @OsakaLOOP*