### PR TITLE
feat: Add API endpoints for QQBot integration

### DIFF
--- a/docs/api/qqbot-api.md
+++ b/docs/api/qqbot-api.md
@@ -1,0 +1,141 @@
+# QQBot (Astrobot) API Documentation
+
+This document describes the API endpoints provided for the QQBot integration. The bot is expected to fetch structured JSON data from these endpoints and handle the actual rendering (e.g., generating PNG images) on its end.
+
+## Base URL
+\`https://<your-domain>/api/qqbot\`
+
+---
+
+## 1. Get User Data
+
+Retrieve a user's total statistics and recent trips.
+
+**Endpoint:** \`/user\`
+**Method:** \`GET\`
+
+### Query Parameters
+
+| Parameter | Type   | Required | Description |
+| --------- | ------ | -------- | ----------- |
+| \`key\`     | string | Yes*     | The user's personal \`card_key\`. |
+| \`hash\`    | string | Yes*     | The hash of a shared folder badge. |
+| \`limit\`   | number | No       | Number of recent trips to return. Default: 10, Max: 50. |
+
+*\* Either \`key\` or \`hash\` must be provided.*
+
+### Example Response (200 OK)
+
+\`\`\`json
+{
+  "username": "Traveller Alpha",
+  "stats": {
+    "total_trips": 142,
+    "total_distance": 5240.5,
+    "total_lines": 35
+  },
+  "recent_trips": [
+    {
+      "id": "uuid-string",
+      "title": "Commute to Shinjuku",
+      "date": "2023-10-25",
+      "distance": 12.5,
+      "lines": ["Yamanote Line", "Chuo Line"],
+      "stations": ["Tokyo", "Kanda", "Shinjuku"],
+      "path": [{ "x": 0, "y": 0 }, { "x": 100, "y": 0 }]
+    }
+  ]
+}
+\`\`\`
+
+---
+
+## 2. Record New Trip
+
+Submit a new trip for a user. The API will prepend the trip to the user's history and automatically update their statistics and the cached \`latest_5\` for badge rendering.
+
+**Endpoint:** \`/record\`
+**Method:** \`POST\`
+**Headers:** \`Content-Type: application/json\`
+
+### Request Body
+
+| Field      | Type     | Required | Description |
+| ---------- | -------- | -------- | ----------- |
+| \`key\`      | string   | Yes      | The user's personal \`card_key\`. |
+| \`title\`    | string   | No       | The name of the trip. Default: "Bot Trip on {date}". |
+| \`date\`     | string   | No       | The date of the trip (YYYY-MM-DD). Default: Today. |
+| \`distance\` | number   | No       | Total distance in kilometers. Default: 0. |
+| \`stations\` | array    | No       | Array of station names or objects \`{ id: string, name: string }\`. |
+| \`lines\`    | array    | No       | Array of line names or objects \`{ id: string, name: string }\`. |
+
+### Example Request
+
+\`\`\`json
+{
+  "key": "user-secret-key-123",
+  "title": "Weekend Trip to Osaka",
+  "date": "2023-10-26",
+  "distance": 515.2,
+  "stations": ["Tokyo", "Shinagawa", "Shin-Osaka"],
+  "lines": ["Tokaido Shinkansen"]
+}
+\`\`\`
+
+### Example Response (200 OK)
+
+\`\`\`json
+{
+  "success": true,
+  "message": "Trip recorded successfully",
+  "trip": {
+    "id": "new-uuid-string",
+    "title": "Weekend Trip to Osaka",
+    "distance": 515.2
+  },
+  "updated_stats": {
+    "total_trips": 143,
+    "total_distance": 5755.7,
+    "total_lines": 36
+  }
+}
+\`\`\`
+
+---
+
+## 3. Global Statistics
+
+Retrieve global rankings and statistics.
+*(Note: Data is currently mocked pending migration to a SQL backend).*
+
+**Endpoint:** \`/global\`
+**Method:** \`GET\`
+
+### Query Parameters
+
+| Parameter | Type   | Required | Description |
+| --------- | ------ | -------- | ----------- |
+| \`type\`    | string | Yes      | The type of data to retrieve. Options: \`leaderboard\`, \`stations\`, \`lines\`. |
+
+### Example Response (200 OK)
+
+\`\`\`json
+{
+  "type": "leaderboard",
+  "description": "Top users ranked by total distance (Mocked Data until SQL migration)",
+  "rankings": [
+    {
+      "rank": 1,
+      "username": "Traveller Alpha",
+      "distance": 12540,
+      "trips": 340
+    },
+    {
+      "rank": 2,
+      "username": "Metro Fanatic",
+      "distance": 9820,
+      "trips": 280
+    }
+  ]
+}
+\`\`\`

--- a/docs/api/qqbot-types.ts
+++ b/docs/api/qqbot-types.ts
@@ -1,0 +1,119 @@
+/**
+ * User Statistics and Trip History Response
+ */
+export interface UserStatsResponse {
+    username: string;
+    stats: {
+        total_trips: number;
+        total_distance: number;
+        total_lines: number;
+    };
+    recent_trips: Trip[];
+}
+
+export interface Trip {
+    id: string;
+    title: string;
+    date: string;
+    distance: number;
+    lines: string[]; // Normalized to string array for the bot payload
+    stations: string[]; // Normalized to string array for the bot payload
+    path: PathCoordinate[] | null; // Raw coordinates for rendering paths if needed
+}
+
+export interface PathCoordinate {
+    x: number;
+    y: number;
+}
+
+/**
+ * Record New Trip Request Body
+ */
+export interface RecordTripRequest {
+    key: string; // The user's auth key
+    title?: string;
+    date?: string; // Format: YYYY-MM-DD
+    distance?: number;
+    stations?: string[] | { id: string; name: string }[];
+    lines?: string[] | { id: string; name: string }[];
+}
+
+/**
+ * Record New Trip Response
+ */
+export interface RecordTripResponse {
+    success: boolean;
+    message: string;
+    trip: {
+        id: string;
+        title: string;
+        distance: number;
+    };
+    updated_stats: {
+        total_trips: number;
+        total_distance: number;
+        total_lines: number;
+    };
+}
+
+/**
+ * Global Statistics Response Types
+ */
+
+// Base type for global responses
+export interface GlobalBaseResponse {
+    type: 'leaderboard' | 'stations' | 'lines';
+    description: string;
+}
+
+// Global Leaderboard
+export interface GlobalLeaderboardResponse extends GlobalBaseResponse {
+    type: 'leaderboard';
+    rankings: LeaderboardEntry[];
+}
+
+export interface LeaderboardEntry {
+    rank: number;
+    username: string;
+    distance: number;
+    trips: number;
+}
+
+// Most Visited Stations
+export interface GlobalStationsResponse extends GlobalBaseResponse {
+    type: 'stations';
+    rankings: StationRankingEntry[];
+}
+
+export interface StationRankingEntry {
+    rank: number;
+    name: string;
+    company: string;
+    visits: number;
+}
+
+// Most Travelled Lines
+export interface GlobalLinesResponse extends GlobalBaseResponse {
+    type: 'lines';
+    rankings: LineRankingEntry[];
+}
+
+export interface LineRankingEntry {
+    rank: number;
+    name: string;
+    company: string;
+    riders: number;
+}
+
+// Union Type for generic fetching
+export type GlobalStatsResponse =
+    | GlobalLeaderboardResponse
+    | GlobalStationsResponse
+    | GlobalLinesResponse;
+
+/**
+ * Standard API Error Response
+ */
+export interface APIErrorResponse {
+    error: string;
+}

--- a/public/functions/api/qqbot/global.js
+++ b/public/functions/api/qqbot/global.js
@@ -1,0 +1,75 @@
+export async function onRequest(event) {
+    const url = new URL(event.request.url);
+    const type = url.searchParams.get("type"); // leaderboard, stations, lines
+
+    const headers = {
+        "Content-Type": "application/json",
+        "Access-Control-Allow-Origin": "*"
+    };
+
+    const errorJson = (msg, status = 400) => new Response(JSON.stringify({ error: msg }), { status, headers });
+
+    if (!type) {
+        return errorJson("Parameter 'type' is required (leaderboard, stations, lines)");
+    }
+
+    try {
+        // Since querying all users across the KV namespace is highly inefficient,
+        // and backend SQL migration is planned, we will return mocked data here
+        // as a temporary placeholder to unblock the QQBot integration.
+
+        let responseData = {};
+
+        switch (type.toLowerCase()) {
+            case "leaderboard":
+                responseData = {
+                    type: "leaderboard",
+                    description: "Top users ranked by total distance (Mocked Data until SQL migration)",
+                    rankings: [
+                        { rank: 1, username: "Traveller Alpha", distance: 12540, trips: 340 },
+                        { rank: 2, username: "Metro Fanatic", distance: 9820, trips: 280 },
+                        { rank: 3, username: "Rail Master", distance: 8400, trips: 150 },
+                        { rank: 4, username: "Commuter Joe", distance: 5100, trips: 420 },
+                        { rank: 5, username: "Casual Rider", distance: 3200, trips: 85 }
+                    ]
+                };
+                break;
+
+            case "stations":
+                responseData = {
+                    type: "stations",
+                    description: "Most visited stations globally (Mocked Data until SQL migration)",
+                    rankings: [
+                        { rank: 1, name: "Shinjuku", company: "JR East", visits: 15420 },
+                        { rank: 2, name: "Tokyo", company: "JR East", visits: 12100 },
+                        { rank: 3, name: "Shibuya", company: "JR East", visits: 9800 },
+                        { rank: 4, name: "Ikebukuro", company: "JR East", visits: 8500 },
+                        { rank: 5, name: "Umeda", company: "JR West", visits: 7200 }
+                    ]
+                };
+                break;
+
+            case "lines":
+                responseData = {
+                    type: "lines",
+                    description: "Most travelled lines globally (Mocked Data until SQL migration)",
+                    rankings: [
+                        { rank: 1, name: "Yamanote Line", company: "JR East", riders: 25400 },
+                        { rank: 2, name: "Chuo Line", company: "JR East", riders: 18200 },
+                        { rank: 3, name: "Tokaido Shinkansen", company: "JR Central", riders: 15100 },
+                        { rank: 4, name: "Ginza Line", company: "Tokyo Metro", riders: 12400 },
+                        { rank: 5, name: "Midosuji Line", company: "Osaka Metro", riders: 9800 }
+                    ]
+                };
+                break;
+
+            default:
+                return errorJson("Invalid type. Must be one of: leaderboard, stations, lines", 400);
+        }
+
+        return new Response(JSON.stringify(responseData), { status: 200, headers });
+
+    } catch (e) {
+        return errorJson(e.message, 500);
+    }
+}

--- a/public/functions/api/qqbot/record.js
+++ b/public/functions/api/qqbot/record.js
@@ -1,0 +1,130 @@
+export async function onRequest(event) {
+    const headers = {
+        "Content-Type": "application/json",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "POST, OPTIONS",
+        "Access-Control-Allow-Headers": "Content-Type, Authorization"
+    };
+
+    if (event.request.method === "OPTIONS") {
+        return new Response(null, { headers });
+    }
+
+    if (event.request.method !== "POST") {
+        return new Response(JSON.stringify({ error: "Method Not Allowed" }), { status: 405, headers });
+    }
+
+    const errorJson = (msg, status = 400) => new Response(JSON.stringify({ error: msg }), { status, headers });
+
+    try {
+        const DB = globalThis.RAILROUND_KV;
+        if (!DB) return errorJson("KV Error", 500);
+
+        let body;
+        try {
+            body = await event.request.json();
+        } catch (e) {
+            return errorJson("Invalid JSON body");
+        }
+
+        const { key, title, date, distance, stations, lines } = body;
+
+        if (!key) return errorJson("User Key is required");
+
+        // 1. Authenticate user using the key
+        const username = await DB.get(`card_key:${key}`);
+        if (!username) return errorJson("Invalid Key", 401);
+
+        const userKey = `user:${username}`;
+        const dataRaw = await DB.get(userKey);
+
+        if (!dataRaw) return errorJson("User data not found", 404);
+
+        const data = JSON.parse(dataRaw);
+
+        // 2. Build the new trip object
+        const newTripId = crypto.randomUUID();
+        const tripDate = date || new Date().toISOString().split('T')[0];
+        const tripDistance = parseFloat(distance) || 0;
+
+        // Bot typically just passes strings. Let's normalize to objects expected by frontend if possible
+        const parsedStations = Array.isArray(stations) ? stations.map((s, idx) => ({
+            id: typeof s === 'string' ? s : (s.id || `st_${idx}`),
+            name: typeof s === 'string' ? s : (s.name || "Unknown")
+        })) : [];
+
+        const parsedLines = Array.isArray(lines) ? lines.map((l, idx) => ({
+             id: typeof l === 'string' ? l : (l.id || `ln_${idx}`),
+             name: typeof l === 'string' ? l : (l.name || "Unknown")
+        })) : [];
+
+        const newTrip = {
+            id: newTripId,
+            title: title || `Bot Trip on ${tripDate}`,
+            date: tripDate,
+            distance: tripDistance,
+            stations: parsedStations,
+            lines: parsedLines,
+            // Provide a dummy horizontal path if nothing else is available
+            // so the card.js doesn't crash if it expects svg_points
+            path: [{x: 0, y: 0}, {x: 100, y: 0}]
+        };
+
+        // 3. Update User Data
+        data.trips = data.trips || [];
+        // Insert at beginning assuming it's the latest
+        data.trips.unshift(newTrip);
+
+        // Update latest_5 (for the card.js SVG generation)
+        data.latest_5 = data.latest_5 || { count: 0, dist: 0, lines: 0, latest: [] };
+        data.latest_5.latest = data.latest_5.latest || [];
+
+        // Recalculate totals
+        data.latest_5.count = data.trips.length;
+        data.latest_5.dist = data.trips.reduce((sum, t) => sum + (parseFloat(t.distance) || 0), 0);
+
+        // Recalculate unique lines
+        const allLines = new Set();
+        data.trips.forEach(t => {
+            if (t.lines && Array.isArray(t.lines)) {
+                t.lines.forEach(l => allLines.add(l.id || l.name || l));
+            }
+        });
+        data.latest_5.lines = allLines.size;
+
+        // Build simplified latest list for the card (limit 5)
+        const newLatestTrip = {
+            title: newTrip.title,
+            date: newTrip.date,
+            dist: newTrip.distance,
+            // A simple horizontal line for the SVG badge preview since bot doesn't know exact map coordinates
+            svg_points: "M 0 15 L 100 15"
+        };
+
+        data.latest_5.latest.unshift(newLatestTrip);
+        if (data.latest_5.latest.length > 5) {
+            data.latest_5.latest = data.latest_5.latest.slice(0, 5);
+        }
+
+        // 4. Save back to KV
+        await DB.put(userKey, JSON.stringify(data));
+
+        return new Response(JSON.stringify({
+            success: true,
+            message: "Trip recorded successfully",
+            trip: {
+                id: newTripId,
+                title: newTrip.title,
+                distance: newTrip.distance
+            },
+            updated_stats: {
+                total_trips: data.latest_5.count,
+                total_distance: data.latest_5.dist,
+                total_lines: data.latest_5.lines
+            }
+        }), { status: 200, headers });
+
+    } catch (e) {
+        return errorJson(e.message, 500);
+    }
+}

--- a/public/functions/api/qqbot/user.js
+++ b/public/functions/api/qqbot/user.js
@@ -1,0 +1,115 @@
+export async function onRequest(event) {
+    const url = new URL(event.request.url);
+    const key = url.searchParams.get("key");
+    const hash = url.searchParams.get("hash");
+    let limit = parseInt(url.searchParams.get("limit") || "10", 10);
+
+    // Cap limit to a reasonable number to avoid huge payloads
+    if (limit > 50) limit = 50;
+
+    const headers = {
+        "Content-Type": "application/json",
+        "Access-Control-Allow-Origin": "*"
+    };
+
+    const errorJson = (msg, status = 400) => new Response(JSON.stringify({ error: msg }), { status, headers });
+
+    if (!key && !hash) {
+        return errorJson("Key or Hash missing");
+    }
+
+    try {
+        const DB = globalThis.RAILROUND_KV;
+        if (!DB) return errorJson("KV Error", 500);
+
+        let username = null;
+        let isGlobalEnabled = true;
+
+        if (hash) {
+            // Folder Badge Mode
+            const badgeDataRaw = await DB.get(`badge:${hash}`);
+            if (!badgeDataRaw) return errorJson("Invalid Hash", 404);
+
+            const badgeData = JSON.parse(badgeDataRaw);
+            username = badgeData.username;
+
+            if (username) {
+                const userKey = `user:${username}`;
+                const userDataRaw = await DB.get(userKey);
+                if (userDataRaw) {
+                     const u = JSON.parse(userDataRaw);
+                     if (u.badge_settings?.enabled === false) {
+                         isGlobalEnabled = false;
+                     }
+                }
+            }
+        } else if (key) {
+            // Global Badge Mode
+            username = await DB.get(`card_key:${key}`);
+            if (!username) return errorJson("Invalid Key", 404);
+        }
+
+        if (!username) return errorJson("User not found", 404);
+
+        const userKey = `user:${username}`;
+        const dataRaw = await DB.get(userKey);
+
+        if (!dataRaw) {
+             return errorJson("User data not found", 404);
+        }
+
+        const data = JSON.parse(dataRaw);
+
+        // Check Master Switch
+        if (data.badge_settings?.enabled === false) {
+            isGlobalEnabled = false;
+        }
+
+        if (!isGlobalEnabled) {
+            return errorJson("Data access disabled by user", 403);
+        }
+
+        // Calculate total stats if not pre-calculated in latest_5 or if we need to be precise
+        // The card.js uses data.latest_5 for stats. Let's use that if available, else calculate.
+        let totalStats = data.latest_5 || { count: 0, dist: 0, lines: 0 };
+
+        // Extract recent trips from the full trips array
+        let recentTrips = [];
+        if (data.trips && Array.isArray(data.trips)) {
+            // Sort by date descending
+            const sortedTrips = [...data.trips].sort((a, b) => {
+                const dateA = a.date ? new Date(a.date).getTime() : 0;
+                const dateB = b.date ? new Date(b.date).getTime() : 0;
+                return dateB - dateA;
+            });
+
+            recentTrips = sortedTrips.slice(0, limit).map(trip => {
+                // Return a simplified, clean object
+                return {
+                    id: trip.id,
+                    title: trip.title || "Untitled Trip",
+                    date: trip.date,
+                    distance: trip.distance || 0,
+                    lines: trip.lines ? trip.lines.map(l => l.name || l.id) : [],
+                    stations: trip.stations ? trip.stations.map(s => s.name || s.id) : [],
+                    path: trip.path || null // Include raw path coordinates if the bot needs to draw it
+                };
+            });
+        }
+
+        const responseData = {
+            username: username,
+            stats: {
+                total_trips: totalStats.count || data.trips?.length || 0,
+                total_distance: totalStats.dist || 0,
+                total_lines: totalStats.lines || 0
+            },
+            recent_trips: recentTrips
+        };
+
+        return new Response(JSON.stringify(responseData), { status: 200, headers });
+
+    } catch (e) {
+        return errorJson(e.message, 500);
+    }
+}


### PR DESCRIPTION
This submission introduces a new set of JSON-based Serverless APIs specifically designed for the QQBot (Astrobot) integration. Since Cloudflare Workers lack native canvas/WASM capabilities to efficiently render PNGs, the API returns structured JSON, offloading the image rendering responsibility to the bot framework.

The integration supports three main endpoints:
1. `/api/qqbot/user`: Fetches a specific user's lifetime statistics and `n` recent trips.
2. `/api/qqbot/global`: Returns mock global stats (Leaderboard, Most Visited Stations/Lines) to unblock the bot development until the backend SQL migration.
3. `/api/qqbot/record`: Allows the bot to securely POST new trip data back into the user's KV store, calculating totals and syncing the simplified `latest_5` cache automatically.

---
*PR created automatically by Jules for task [2548905620681640108](https://jules.google.com/task/2548905620681640108) started by @OsakaLOOP*