### PR TITLE
Implement Leaflet local tile caching and preloading

### DIFF
--- a/src/components/MapComponent.jsx
+++ b/src/components/MapComponent.jsx
@@ -6,6 +6,7 @@ import { PinEditor } from './PinEditor';
 import { FabButton } from './FabButton';
 import StationMenu from './StationMenu';
 import { findNearestPointOnLine } from '../utils/routeFinder';
+import { cachedTileLayer } from '../utils/CachedTileLayer';
 
 // Fix Leaflet icons (standard fix)
 import iconRetinaUrl from 'leaflet/dist/images/marker-icon-2x.png';
@@ -38,13 +39,22 @@ export default function MapComponent() {
         if (!mapRef.current || mapInstance.current) return;
         const map = L.map(mapRef.current, { zoomControl: true, preferCanvas: true }).setView([35.68, 139.76], 10);
 
-        const light = L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', { attribution: '© CARTO', subdomains: 'abcd', maxZoom: 20 });
-        const dark = L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', { attribution: '© CARTO', subdomains: 'abcd', maxZoom: 20 });
-        const rail = L.tileLayer('https://{s}.tiles.openrailwaymap.org/standard/{z}/{x}/{y}.png', { maxZoom: 20, opacity: 0, attribution: '© OpenRailwayMap' });
+        const light = cachedTileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', { attribution: '© CARTO', subdomains: 'abcd', maxZoom: 20, layerName: 'light' });
+        const dark = cachedTileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', { attribution: '© CARTO', subdomains: 'abcd', maxZoom: 20, layerName: 'dark' });
+        const rail = cachedTileLayer('https://{s}.tiles.openrailwaymap.org/standard/{z}/{x}/{y}.png', { maxZoom: 20, opacity: 0, attribution: '© OpenRailwayMap', layerName: 'rail' });
         railLayerRef.current = rail;
 
         dark.addTo(map); rail.addTo(map);
         L.control.layers({ "标准 (light)": light, "暗色 (Dark)": dark }, { "详细配线图 (OpenRailwayMap)": rail }, { position: 'topright' }).addTo(map);
+
+        const preloadActiveLayers = () => {
+            if (map.hasLayer(light)) light.preloadTiles(map);
+            if (map.hasLayer(dark)) dark.preloadTiles(map);
+            if (map.hasLayer(rail)) rail.preloadTiles(map);
+        };
+
+        map.on('moveend', preloadActiveLayers);
+        map.on('zoomend', preloadActiveLayers);
 
         // Layers
         baseLinesLayer.current = L.layerGroup(); // Not added initially

--- a/src/utils/CachedTileLayer.js
+++ b/src/utils/CachedTileLayer.js
@@ -1,0 +1,154 @@
+import L from 'leaflet';
+import { getTile, putTile } from './tileCache';
+
+const MAX_CONCURRENT_FETCHES = 6;
+let activeFetches = 0;
+const fetchQueue = [];
+
+function processFetchQueue() {
+    if (activeFetches >= MAX_CONCURRENT_FETCHES || fetchQueue.length === 0) {
+        return;
+    }
+
+    const { url, cacheKey, resolve, reject } = fetchQueue.shift();
+    activeFetches++;
+
+    fetch(url, { mode: 'cors' })
+        .then(response => {
+            if (!response.ok) throw new Error('Network response was not ok');
+            return response.blob();
+        })
+        .then(blob => {
+            putTile(cacheKey, blob).catch(e => console.warn('Failed to cache tile:', e));
+            resolve(blob);
+        })
+        .catch(err => {
+            reject(err);
+        })
+        .finally(() => {
+            activeFetches--;
+            processFetchQueue();
+        });
+}
+
+function queueFetch(url, cacheKey) {
+    return new Promise((resolve, reject) => {
+        fetchQueue.push({ url, cacheKey, resolve, reject });
+        processFetchQueue();
+    });
+}
+
+
+export const CachedTileLayer = L.TileLayer.extend({
+    initialize: function (url, options) {
+        L.TileLayer.prototype.initialize.call(this, url, options);
+        this.layerName = options.layerName || btoa(url).slice(0, 10);
+    },
+
+    createTile: function (coords, done) {
+        const tile = document.createElement('img');
+
+        L.DomEvent.on(tile, 'load', L.Util.bind(this._tileOnLoad, this, done, tile));
+        L.DomEvent.on(tile, 'error', L.Util.bind(this._tileOnError, this, done, tile));
+
+        if (this.options.crossOrigin || this.options.crossOrigin === '') {
+            tile.crossOrigin = this.options.crossOrigin === true ? '' : this.options.crossOrigin;
+        }
+
+        tile.alt = '';
+        tile.setAttribute('role', 'presentation');
+
+        const url = this.getTileUrl(coords);
+        const cacheKey = `${this.layerName}_${coords.z}_${coords.x}_${coords.y}`;
+
+        // Attempt to load from cache
+        getTile(cacheKey)
+            .then(blob => {
+                if (blob) {
+                    const objectUrl = URL.createObjectURL(blob);
+                    tile._objectUrl = objectUrl; // Store reference to revoke later
+                    tile.src = objectUrl;
+                } else {
+                    // Fetch and cache
+                    queueFetch(url, cacheKey)
+                        .then(newBlob => {
+                            const objectUrl = URL.createObjectURL(newBlob);
+                            tile._objectUrl = objectUrl;
+                            tile.src = objectUrl;
+                        })
+                        .catch(() => {
+                            // Fallback to normal URL on fetch failure (though it might fail again)
+                            tile.src = url;
+                        });
+                }
+            })
+            .catch(() => {
+                // If IDB fails, fallback to normal URL
+                tile.src = url;
+            });
+
+        return tile;
+    },
+
+    _removeTile: function (key) {
+        const tile = this._tiles[key].el;
+        if (tile && tile._objectUrl) {
+            URL.revokeObjectURL(tile._objectUrl);
+            delete tile._objectUrl;
+        }
+        L.TileLayer.prototype._removeTile.call(this, key);
+    },
+
+    preloadTiles: function (map) {
+        if (!map) return;
+
+        const bounds = map.getBounds();
+        const zoom = map.getZoom();
+
+        if (zoom > this.options.maxZoom || zoom < this.options.minZoom) return;
+
+        const nw = map.project(bounds.getNorthWest(), zoom);
+        const se = map.project(bounds.getSouthEast(), zoom);
+
+        const tileSize = this.getTileSize();
+
+        const tileBounds = L.bounds(
+            nw.divideBy(tileSize.x).floor(),
+            se.divideBy(tileSize.y).floor()
+        );
+
+        // Expand by 3 tiles in each direction
+        const minX = tileBounds.min.x - 3;
+        const maxX = tileBounds.max.x + 3;
+        const minY = tileBounds.min.y - 3;
+        const maxY = tileBounds.max.y + 3;
+
+        for (let x = minX; x <= maxX; x++) {
+            for (let y = minY; y <= maxY; y++) {
+                const coords = new L.Point(x, y);
+                coords.z = zoom;
+
+                // Keep coords within valid ranges if needed, standard tile layer usually wraps or limits
+                const wrappedCoords = this._wrapCoords(coords.clone());
+
+                if (!wrappedCoords) continue; // Outside bounds
+
+                // Optionally, check if it's within bounds to prevent fetching beyond map edges if noWrap is used
+                if (!this._isValidTile(wrappedCoords)) continue;
+
+                const url = this.getTileUrl(wrappedCoords);
+                const cacheKey = `${this.layerName}_${wrappedCoords.z}_${wrappedCoords.x}_${wrappedCoords.y}`;
+
+                getTile(cacheKey).then(blob => {
+                    if (!blob) {
+                        queueFetch(url, cacheKey).catch(() => {});
+                    }
+                }).catch(() => {});
+            }
+        }
+    }
+});
+
+export function cachedTileLayer(url, options) {
+    return new CachedTileLayer(url, options);
+}

--- a/src/utils/tileCache.js
+++ b/src/utils/tileCache.js
@@ -1,0 +1,63 @@
+const DB_NAME = 'LeafletTileCacheDB';
+const STORE_NAME = 'tiles';
+const DB_VERSION = 1;
+
+let dbPromise = null;
+
+export function initDB() {
+    if (!dbPromise) {
+        dbPromise = new Promise((resolve, reject) => {
+            const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+            request.onupgradeneeded = (event) => {
+                const db = event.target.result;
+                if (!db.objectStoreNames.contains(STORE_NAME)) {
+                    db.createObjectStore(STORE_NAME);
+                }
+            };
+
+            request.onsuccess = (event) => {
+                resolve(event.target.result);
+            };
+
+            request.onerror = (event) => {
+                reject(event.target.error);
+            };
+        });
+    }
+    return dbPromise;
+}
+
+export async function getTile(key) {
+    const db = await initDB();
+    return new Promise((resolve, reject) => {
+        const transaction = db.transaction([STORE_NAME], 'readonly');
+        const store = transaction.objectStore(STORE_NAME);
+        const request = store.get(key);
+
+        request.onsuccess = (event) => {
+            resolve(event.target.result);
+        };
+
+        request.onerror = (event) => {
+            reject(event.target.error);
+        };
+    });
+}
+
+export async function putTile(key, blob) {
+    const db = await initDB();
+    return new Promise((resolve, reject) => {
+        const transaction = db.transaction([STORE_NAME], 'readwrite');
+        const store = transaction.objectStore(STORE_NAME);
+        const request = store.put(blob, key);
+
+        request.onsuccess = () => {
+            resolve();
+        };
+
+        request.onerror = (event) => {
+            reject(event.target.error);
+        };
+    });
+}


### PR DESCRIPTION
Implemented local caching for Leaflet basemap tiles using an IndexedDB wrapper (`tileCache.js`) and a custom `CachedTileLayer.js` extending `L.TileLayer`. Added logic to proactively preload tiles in a 3x3 grid beyond the current viewport during zoom and pan events, improving offline capability and perceived performance. Fixed Leaflet 1.0 wrapping checks in the preloading logic.

---
*PR created automatically by Jules for task [2865594276614192684](https://jules.google.com/task/2865594276614192684) started by @OsakaLOOP*