### PR TITLE
Implement Local Map Tile Caching and Preloading

### DIFF
--- a/src/components/map/MapContainer.tsx
+++ b/src/components/map/MapContainer.tsx
@@ -4,6 +4,7 @@ import 'leaflet/dist/leaflet.css';
 import { useStore, PinMode, StationMenuData, CustomFeatureCollection, CustomGeoJSONFeature } from '../../store';
 import { findNearestPointOnLine } from '../../utils/railwayRouting';
 import { syncLeafletLayerGroup } from '../../utils/leafletSync';
+import { cachedTileLayer } from '../../utils/CachedTileLayer';
 import { useShallow } from 'zustand/react/shallow';
 import toast from 'react-hot-toast';
 
@@ -134,9 +135,9 @@ export const MapContainer: React.FC<Props> = ({ setStationMenu, isDraggingRef })
     const initMap = () => {
         if (!mapRef.current || mapInstance.current ) return;
         const map = L.map(mapRef.current, { zoomControl: true, preferCanvas: true }).setView([35.68, 139.76], 10);
-        const light = L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', { attribution: '© CARTO', subdomains: ['a','b','c','d'], maxZoom: 20 });
-        const dark = L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', { attribution: '© CARTO', subdomains: ['a','b','c','d'], maxZoom: 20 });
-        const rail = L.tileLayer('https://{s}.tiles.openrailwaymap.org/standard/{z}/{x}/{y}.png', { maxZoom: 20, opacity: 0, attribution: '© OpenRailwayMap' });
+        const light = cachedTileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', { attribution: '© CARTO', subdomains: ['a','b','c','d'], maxZoom: 20 });
+        const dark = cachedTileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', { attribution: '© CARTO', subdomains: ['a','b','c','d'], maxZoom: 20 });
+        const rail = cachedTileLayer('https://{s}.tiles.openrailwaymap.org/standard/{z}/{x}/{y}.png', { maxZoom: 20, opacity: 0, attribution: '© OpenRailwayMap' });
         railLayerRef.current = rail;
 
         const handleTileError = (e: any) => {

--- a/src/utils/CachedTileLayer.js
+++ b/src/utils/CachedTileLayer.js
@@ -1,0 +1,143 @@
+import * as L from 'leaflet';
+import { tileCache } from './tileCache';
+
+export const CachedTileLayer = L.TileLayer.extend({
+  initialize: function (url, options) {
+    L.TileLayer.prototype.initialize.call(this, url, options);
+    this._preloadingUrls = new Set();
+    this.on('tileunload', this._onTileRemove, this);
+  },
+
+  _onTileRemove: function(e) {
+    if (e.tile && e.tile._objectUrl) {
+      URL.revokeObjectURL(e.tile._objectUrl);
+      e.tile._objectUrl = null;
+    }
+  },
+
+  createTile: function (coords, done) {
+    const tile = document.createElement('img');
+    tile.setAttribute('role', 'presentation');
+
+    L.DomEvent.on(tile, 'load', L.bind(this._tileOnLoad, this, done, tile));
+    L.DomEvent.on(tile, 'error', L.bind(this._tileOnError, this, done, tile));
+
+    if (this.options.crossOrigin || this.options.crossOrigin === '') {
+      tile.crossOrigin = this.options.crossOrigin === true ? '' : this.options.crossOrigin;
+    }
+
+    tile.alt = '';
+    const url = this.getTileUrl(coords);
+
+    tileCache.get(url).then(blob => {
+      if (blob) {
+        const objectUrl = URL.createObjectURL(blob);
+        tile._objectUrl = objectUrl;
+        tile.src = objectUrl;
+      } else {
+        this._fetchAndCacheTile(url, tile);
+      }
+    }).catch(err => {
+      console.error('Error getting tile from cache', err);
+      tile.src = url;
+    });
+
+    return tile;
+  },
+
+  _fetchAndCacheTile: function (url, tileElement) {
+    fetch(url)
+      .then(response => {
+        if (!response.ok) {
+           throw new Error('Network response was not ok');
+        }
+        return response.blob();
+      })
+      .then(blob => {
+        tileCache.set(url, blob).catch(e => console.error("Failed to save tile to cache", e));
+        if (tileElement) {
+          const objectUrl = URL.createObjectURL(blob);
+          tileElement._objectUrl = objectUrl;
+          tileElement.src = objectUrl;
+        }
+      })
+      .catch(error => {
+        // Fallback to regular src assignment on fetch error
+        if (tileElement) {
+          tileElement.src = url;
+        }
+      });
+  },
+
+  _update: function (center) {
+    if (!this._map) { return; }
+
+    const map = this._map;
+    const zoom = Math.round(map.getZoom());
+
+    if (zoom > this.options.maxZoom || zoom < this.options.minZoom) {
+      return;
+    }
+
+    L.TileLayer.prototype._update.call(this, center);
+
+    // Aggressive preloading (3x3 grid)
+    const bounds = map.getPixelBounds();
+    const tileSize = this.getTileSize();
+
+    // Calculate viewport dimensions in tiles
+    const tileBounds = L.bounds(
+      bounds.min.divideBy(tileSize.x).floor(),
+      bounds.max.divideBy(tileSize.y).floor()
+    );
+
+    // Expand bounds by 1x width and 1x height on all sides
+    // So if current bounds is W x H tiles, we load 3W x 3H tiles.
+    const width = tileBounds.max.x - tileBounds.min.x + 1;
+    const height = tileBounds.max.y - tileBounds.min.y + 1;
+
+    const prefetchBounds = L.bounds(
+      L.point(tileBounds.min.x - width, tileBounds.min.y - height),
+      L.point(tileBounds.max.x + width, tileBounds.max.y + height)
+    );
+
+    for (let j = prefetchBounds.min.y; j <= prefetchBounds.max.y; j++) {
+      for (let i = prefetchBounds.min.x; i <= prefetchBounds.max.x; i++) {
+        const coords = new L.Point(i, j);
+        coords.z = zoom;
+
+        if (this._isValidTile(coords)) {
+            const wrappedCoords = this._wrapCoords(coords);
+            const url = this.getTileUrl(wrappedCoords);
+            if (!this._preloadingUrls.has(url)) {
+                this._preloadingUrls.add(url);
+                tileCache.get(url).then(blob => {
+                  if (!blob) {
+                    fetch(url)
+                      .then(response => {
+                          if (response.ok) return response.blob();
+                          throw new Error("Bad response");
+                      })
+                      .then(fetchedBlob => {
+                          tileCache.set(url, fetchedBlob).catch(()=> {});
+                      })
+                      .catch(() => {})
+                      .finally(() => {
+                           this._preloadingUrls.delete(url);
+                      });
+                  } else {
+                     this._preloadingUrls.delete(url);
+                  }
+                }).catch(() => {
+                    this._preloadingUrls.delete(url);
+                });
+            }
+        }
+      }
+    }
+  }
+});
+
+export const cachedTileLayer = function(url, options) {
+  return new CachedTileLayer(url, options);
+};

--- a/src/utils/tileCache.js
+++ b/src/utils/tileCache.js
@@ -1,0 +1,85 @@
+// src/utils/tileCache.js
+const DB_NAME = 'TileCacheDB';
+const DB_VERSION = 1;
+const STORE_NAME = 'tiles';
+
+export const tileCache = {
+  dbPromise: null,
+
+  open() {
+    if (this.dbPromise) return this.dbPromise;
+
+    this.dbPromise = new Promise((resolve, reject) => {
+      const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+      request.onupgradeneeded = (event) => {
+        const db = event.target.result;
+        if (!db.objectStoreNames.contains(STORE_NAME)) {
+          db.createObjectStore(STORE_NAME);
+        }
+      };
+
+      request.onsuccess = (event) => {
+        resolve(event.target.result);
+      };
+
+      request.onerror = (event) => {
+        console.error('TileCache IndexedDB error:', event.target.error);
+        reject(event.target.error);
+      };
+    });
+    return this.dbPromise;
+  },
+
+  async init() {
+      // Clear cache for current session cache behavior
+      await this.clear();
+  },
+
+  async get(key) {
+    const db = await this.open();
+    return new Promise((resolve, reject) => {
+      const transaction = db.transaction(STORE_NAME, 'readonly');
+      const store = transaction.objectStore(STORE_NAME);
+      const request = store.get(key);
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+  },
+
+  async set(key, value) {
+    const db = await this.open();
+    return new Promise((resolve, reject) => {
+      const transaction = db.transaction(STORE_NAME, 'readwrite');
+      const store = transaction.objectStore(STORE_NAME);
+      const request = store.put(value, key);
+      request.onsuccess = () => resolve();
+      request.onerror = () => reject(request.error);
+    });
+  },
+
+  async delete(key) {
+    const db = await this.open();
+    return new Promise((resolve, reject) => {
+      const transaction = db.transaction(STORE_NAME, 'readwrite');
+      const store = transaction.objectStore(STORE_NAME);
+      const request = store.delete(key);
+      request.onsuccess = () => resolve();
+      request.onerror = () => reject(request.error);
+    });
+  },
+
+  async clear() {
+    const db = await this.open();
+    return new Promise((resolve, reject) => {
+      const transaction = db.transaction(STORE_NAME, 'readwrite');
+      const store = transaction.objectStore(STORE_NAME);
+      const request = store.clear();
+      request.onsuccess = () => resolve();
+      request.onerror = () => reject(request.error);
+    });
+  }
+};
+
+// Initialize cache clearing
+tileCache.init();


### PR DESCRIPTION
Adds IndexedDB session caching and a 3x3 aggressive preloader for map basemap tiles using a custom Leaflet tile layer extension. Fixes coordinate wrap boundary issues and correctly cleans up object URLs on unload to manage memory efficiently.

---
*PR created automatically by Jules for task [10386243530899216245](https://jules.google.com/task/10386243530899216245) started by @OsakaLOOP*