### PR TITLE
⚡ Bolt: Optimize RouteSlice re-renders in TripsPage

### DIFF
--- a/src/pages/TripsPage.tsx
+++ b/src/pages/TripsPage.tsx
@@ -6,7 +6,7 @@ import { getRouteVisualData } from '../core/tripCalculator';
 import { isMobile } from 'react-device-detect';
 import { useShallow } from 'zustand/react/shallow';
 
-const RouteSlice: React.FC<{ segments: any[] }> = ({ segments }) => {
+const RouteSlice = React.memo(({ segments }: { segments: any[] }) => {
     const { segmentGeometries, railwayData, geoData } = useStore(useShallow(state => ({
         segmentGeometries: state.segmentGeometries,
         railwayData: state.railwayData,
@@ -50,7 +50,19 @@ const RouteSlice: React.FC<{ segments: any[] }> = ({ segments }) => {
             <div className="absolute bottom-2 right-2 text-[10px] font-bold text-gray-600 opacity-100">{Math.round(totalDist)}km</div>
         </div>
     );
-};
+}, (prevProps, nextProps) => {
+    // Custom comparison for segments array to avoid unnecessary re-renders
+    if (prevProps.segments === nextProps.segments) return true;
+    if (prevProps.segments?.length !== nextProps.segments?.length) return false;
+
+    return prevProps.segments.every((seg, idx) => {
+        const nextSeg = nextProps.segments[idx];
+        return seg.id === nextSeg.id &&
+               seg.lineKey === nextSeg.lineKey &&
+               seg.fromId === nextSeg.fromId &&
+               seg.toId === nextSeg.toId;
+    });
+});
 
 import { useUserData } from '../hooks/useUserData';
 


### PR DESCRIPTION
💡 **What:** Wrapped `RouteSlice` component in `React.memo` with a custom equality function.
🎯 **Why:** `RouteSlice` renders SVG maps/paths based on `segments`, but it's used inside a `.map()` list in `TripsPage`. Even if a specific trip hasn't changed, a parent re-render causes new `segments` arrays to be passed down, triggering expensive recalculations and DOM repainting in `RouteSlice` due to referential inequality.
📊 **Impact:** Reduces re-renders of `RouteSlice` drastically when interacting with the page (e.g. dragging, scrolling, updating other trips).
🔬 **Measurement:** Verify using React DevTools Profiler by interacting with the Trips page (e.g. deleting a trip or starting to drag a station) and observing that non-mutated `RouteSlice` components are now skipped during render.

---
*PR created automatically by Jules for task [18443496873155422373](https://jules.google.com/task/18443496873155422373) started by @OsakaLOOP*