### PR TITLE
fix: mobile layout improvements on Trips page

### DIFF
--- a/src/AppLayout.tsx
+++ b/src/AppLayout.tsx
@@ -1002,7 +1002,7 @@ export const AppLayout: React.FC = () => {
 
     return (
         <DragProvider>
-            <div className="flex flex-col h-screen bg-slate-100 font-sans text-slate-800 overflow-visible">
+            <div className="flex flex-col h-[100dvh] bg-slate-100 font-sans text-slate-800 overflow-visible">
                 <Toaster position="top-center" />
                 <Header
                     handleExportKML={handleExportKML}

--- a/src/RailRound.jsx
+++ b/src/RailRound.jsx
@@ -2661,7 +2661,7 @@ function RailLOOPContent() {
   };
 
   return (
-    <div className="flex flex-col h-screen bg-slate-100 font-sans text-slate-800 overflow-visible">
+    <div className="flex flex-col h-[100dvh] bg-slate-100 font-sans text-slate-800 overflow-visible">
       <style>{LEAFLET_CSS}</style>
       <header className="bg-slate-900 text-white p-4 shadow-md z-30 flex justify-between shrink-0">
         <div id="header-title" className="flex items-center gap-2">

--- a/src/components/map/MapContainer.tsx
+++ b/src/components/map/MapContainer.tsx
@@ -682,10 +682,18 @@ export const MapContainer: React.FC<Props> = ({ setStationMenu, isDraggingRef })
                 // @ts-ignore
                 layer._cachedWeight = targetWeight;
 
+                let startX = 0;
+                let startY = 0;
+
                 const handlePointerDown = (e: L.LeafletEvent | L.LeafletMouseEvent) => {
                     L.DomEvent.stopPropagation(e);
 
                     if (pressTimerRef.current) clearTimeout(pressTimerRef.current);
+
+                    const me = e as L.LeafletMouseEvent;
+                    const originalEvent = me.originalEvent as MouseEvent | TouchEvent;
+                    startX = 'clientX' in originalEvent ? originalEvent.clientX : (originalEvent as TouchEvent).touches[0].clientX;
+                    startY = 'clientY' in originalEvent ? originalEvent.clientY : (originalEvent as TouchEvent).touches[0].clientY;
 
                     wasDraggingRef.current = false;
                     map.dragging.disable(); // Immediately prevent map pan
@@ -726,6 +734,22 @@ export const MapContainer: React.FC<Props> = ({ setStationMenu, isDraggingRef })
                     }, 300); // 300ms long press
                 };
 
+                const handlePointerMove = (e: L.LeafletEvent | L.LeafletMouseEvent) => {
+                    if (pressTimerRef.current && !routeDragRef.current.active) {
+                        const me = e as L.LeafletMouseEvent;
+                        const originalEvent = me.originalEvent as MouseEvent | TouchEvent;
+                        const currentX = 'clientX' in originalEvent ? originalEvent.clientX : (originalEvent as TouchEvent).touches[0].clientX;
+                        const currentY = 'clientY' in originalEvent ? originalEvent.clientY : (originalEvent as TouchEvent).touches[0].clientY;
+
+                        // 15px tolerance
+                        if (Math.abs(currentX - startX) > 15 || Math.abs(currentY - startY) > 15) {
+                            clearTimeout(pressTimerRef.current);
+                            pressTimerRef.current = null;
+                            map.dragging.enable();
+                        }
+                    }
+                };
+
                 const handlePointerUp = (e: L.LeafletEvent | L.LeafletMouseEvent) => {
                     if (pressTimerRef.current) {
                         clearTimeout(pressTimerRef.current);
@@ -740,19 +764,25 @@ export const MapContainer: React.FC<Props> = ({ setStationMenu, isDraggingRef })
 
                 layer.on('mousedown', handlePointerDown);
                 layer.on('touchstart', handlePointerDown);
+                layer.on('mousemove', handlePointerMove);
+                layer.on('touchmove', handlePointerMove);
                 layer.on('mouseup', handlePointerUp);
                 layer.on('touchend', handlePointerUp);
 
                 layer.on('click', (e: L.LeafletMouseEvent) => {
                     L.DomEvent.stopPropagation(e);
-                    if (wasDraggingRef.current) {
-                        wasDraggingRef.current = false;
-                        return;
-                    }
 
                     const originalEvent = e.originalEvent as MouseEvent | TouchEvent;
                     const x = 'clientX' in originalEvent ? originalEvent.clientX : (originalEvent as TouchEvent).touches[0].clientX;
                     const y = 'clientY' in originalEvent ? originalEvent.clientY : (originalEvent as TouchEvent).touches[0].clientY;
+
+                    // If was dragged heavily, ignore click
+                    if (wasDraggingRef.current && (Math.abs(x - startX) > 15 || Math.abs(y - startY) > 15)) {
+                        wasDraggingRef.current = false;
+                        return;
+                    }
+                    wasDraggingRef.current = false;
+
                     setStationMenu({ x, y, stationData: { name_ja: f.properties.name || '', lat: f.geometry.coordinates[1], lng: f.geometry.coordinates[0] } });
                 });
                 return layer;

--- a/src/pages/TripsPage.tsx
+++ b/src/pages/TripsPage.tsx
@@ -110,7 +110,8 @@ export const TripsPage: React.FC = () => {
     };
 
     return (
-        <div className="flex-1 flex flex-col overflow-y-auto p-4 space-y-3 pb-4 h-full">
+        <div className="relative h-full w-full flex flex-col overflow-hidden">
+            <div id="trips-scroll-container" className="flex-1 flex flex-col overflow-y-auto p-4 space-y-3 pb-24">
             {trips.length === 0 ? (
                 <div className="text-center text-gray-400 py-10 flex flex-col items-center justify-center flex-1">
                     <Train size={48} className="opacity-20 mb-4"/>
@@ -212,17 +213,127 @@ export const TripsPage: React.FC = () => {
                     );
                 })
             )}
+            </div>
+            <FloatingActionButtons
+                fileInputRef={fileInputRef}
+                handleImportSuica={handleImportSuica}
+                startEditingTrip={startEditingTrip}
+                alwaysVisible={trips.length === 0}
+            />
+        </div>
+    );
+};
+
+export const FloatingActionButtons: React.FC<{
+    fileInputRef: React.RefObject<HTMLInputElement>,
+    handleImportSuica: (event: React.ChangeEvent<HTMLInputElement>) => void,
+    startEditingTrip: (data?: any) => void,
+    alwaysVisible?: boolean
+}> = ({ fileInputRef, handleImportSuica, startEditingTrip, alwaysVisible = false }) => {
+    const [isVisible, setIsVisible] = useState(true);
+    const scrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const lastScrollYRef = useRef(0);
+    const lastScrollTimeRef = useRef(Date.now());
+
+    useEffect(() => {
+        if (alwaysVisible) {
+            setIsVisible(true);
+            if (scrollTimeoutRef.current) {
+                clearTimeout(scrollTimeoutRef.current);
+            }
+            return;
+        }
+
+        const handleScroll = (e: Event) => {
+            const target = e.target as HTMLElement;
+            if (!target) return;
+
+            const currentScrollY = target.scrollTop;
+            const currentTime = Date.now();
+
+            const timeDiff = currentTime - lastScrollTimeRef.current;
+            const scrollDiff = Math.abs(currentScrollY - lastScrollYRef.current);
+
+            if (timeDiff > 0) {
+                const speed = scrollDiff / timeDiff;
+                // Show buttons if scroll speed exceeds threshold
+                if (speed > 0.5) {
+                    setIsVisible(true);
+
+                    if (scrollTimeoutRef.current) {
+                        clearTimeout(scrollTimeoutRef.current);
+                    }
+
+                    scrollTimeoutRef.current = setTimeout(() => {
+                        setIsVisible(false);
+                    }, 2000); // Hide after 2 seconds of inactivity
+                }
+            }
+
+            lastScrollYRef.current = currentScrollY;
+            lastScrollTimeRef.current = currentTime;
+        };
+
+        const container = document.getElementById('trips-scroll-container');
+
+        // Also check if container is actually scrollable. If not scrollable, keep visible.
+        const checkScrollable = () => {
+            if (container) {
+                if (container.scrollHeight <= container.clientHeight) {
+                    setIsVisible(true);
+                    if (scrollTimeoutRef.current) {
+                        clearTimeout(scrollTimeoutRef.current);
+                    }
+                } else if (isVisible && !scrollTimeoutRef.current) {
+                    scrollTimeoutRef.current = setTimeout(() => {
+                        setIsVisible(false);
+                    }, 3000);
+                }
+            }
+        };
+
+        if (container) {
+            container.addEventListener('scroll', handleScroll);
+            // Run initial check
+            setTimeout(checkScrollable, 100);
+            window.addEventListener('resize', checkScrollable);
+        }
+
+        // Initial fade out timer (only if not empty and scrollable)
+        if (!alwaysVisible) {
+            scrollTimeoutRef.current = setTimeout(() => {
+                if (container && container.scrollHeight > container.clientHeight) {
+                    setIsVisible(false);
+                }
+            }, 3000);
+        }
+
+        return () => {
+            if (container) {
+                container.removeEventListener('scroll', handleScroll);
+            }
+            window.removeEventListener('resize', checkScrollable);
+            if (scrollTimeoutRef.current) {
+                clearTimeout(scrollTimeoutRef.current);
+            }
+        };
+    }, [alwaysVisible]);
+
+    return (
+        <div
+            className={`absolute bottom-4 left-4 right-4 z-50 transition-opacity duration-500 ease-in-out ${isVisible || alwaysVisible ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'}`}
+        >
             <DropZone onDrop={(item: any) => {
                 if (item.type === 'station') {
                     const newSegments = [{ id: Date.now().toString(), lineKey: item.lineKey, fromId: item.id, toId: '' }];
                     startEditingTrip({ date: new Date().toISOString().split('T')[0], memo: '', segments: newSegments, cost: 0 });
                 }
             }}>
-                <div className="flex gap-2">
-                    <button id="btn-add-trip" onClick={() => startEditingTrip()} className="flex-1 py-4 border-2 border-dashed border-gray-300 text-gray-400 rounded-xl hover:bg-emerald-50 hover:text-emerald-600 hover:border-emerald-300 font-bold transition-all duration-300 active:scale-[0.98] group flex items-center justify-center gap-2">
+                <div className="flex gap-2 bg-white/90 backdrop-blur-sm p-2 rounded-2xl shadow-lg border border-gray-100">
+                    <button id="btn-add-trip" onClick={() => startEditingTrip()} className="flex-1 py-3 border-2 border-dashed border-gray-300 text-gray-500 rounded-xl hover:bg-emerald-50 hover:text-emerald-600 hover:border-emerald-300 font-bold transition-all duration-300 active:scale-[0.98] group flex items-center justify-center gap-2">
                         <Plus className="group-hover:rotate-90 transition-transform duration-300" size={18} /> 记录新行程
                     </button>
-                    <button onClick={() => fileInputRef.current?.click()} className="flex-none px-4 py-4 border-2 border-dashed border-gray-300 text-gray-400 rounded-xl hover:bg-blue-50 hover:text-blue-600 hover:border-blue-300 font-bold transition-all duration-300 active:scale-[0.98] group flex items-center justify-center gap-2" title="导入 Suica CSV">
+                    <button onClick={() => fileInputRef.current?.click()} className="flex-none px-4 py-3 border-2 border-dashed border-gray-300 text-gray-500 rounded-xl hover:bg-blue-50 hover:text-blue-600 hover:border-blue-300 font-bold transition-all duration-300 active:scale-[0.98] group flex items-center justify-center gap-2" title="导入 Suica CSV">
                         <Upload size={18} />
                     </button>
                     <input type="file" accept=".csv" className="hidden" ref={fileInputRef} onChange={handleImportSuica} />

--- a/src/pages/TripsPage.tsx
+++ b/src/pages/TripsPage.tsx
@@ -111,7 +111,7 @@ export const TripsPage: React.FC = () => {
 
     return (
         <div className="relative h-full w-full flex flex-col overflow-hidden">
-            <div id="trips-scroll-container" className="flex-1 flex flex-col overflow-y-auto p-4 space-y-3 pb-24">
+            <div id="trips-scroll-container" className="flex-1 flex flex-col overflow-y-auto p-4 space-y-3 pb-4">
             {trips.length === 0 ? (
                 <div className="text-center text-gray-400 py-10 flex flex-col items-center justify-center flex-1">
                     <Train size={48} className="opacity-20 mb-4"/>

--- a/src/pages/TripsPage.tsx
+++ b/src/pages/TripsPage.tsx
@@ -235,6 +235,27 @@ export const FloatingActionButtons: React.FC<{
     const lastScrollYRef = useRef(0);
     const lastScrollTimeRef = useRef(Date.now());
 
+    const handleMouseEnter = () => {
+        if (alwaysVisible) return;
+        setIsVisible(true);
+        if (scrollTimeoutRef.current) {
+            clearTimeout(scrollTimeoutRef.current);
+        }
+    };
+
+    const handleMouseLeave = () => {
+        if (alwaysVisible) return;
+        const container = document.getElementById('trips-scroll-container');
+        if (container && container.scrollHeight > container.clientHeight) {
+            if (scrollTimeoutRef.current) {
+                clearTimeout(scrollTimeoutRef.current);
+            }
+            scrollTimeoutRef.current = setTimeout(() => {
+                setIsVisible(false);
+            }, 2000);
+        }
+    };
+
     useEffect(() => {
         if (alwaysVisible) {
             setIsVisible(true);
@@ -321,7 +342,11 @@ export const FloatingActionButtons: React.FC<{
 
     return (
         <div
-            className={`absolute bottom-4 left-4 right-4 z-50 transition-opacity duration-500 ease-in-out ${isVisible || alwaysVisible ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'}`}
+            className={`absolute bottom-4 left-4 right-4 z-50 transition-all duration-500 ease-[cubic-bezier(0.34,1.56,0.64,1)] ${isVisible || alwaysVisible ? 'opacity-100 translate-y-0 scale-100 pointer-events-auto' : 'opacity-0 translate-y-8 scale-95 pointer-events-none'}`}
+            onMouseEnter={handleMouseEnter}
+            onMouseLeave={handleMouseLeave}
+            onTouchStart={handleMouseEnter}
+            onTouchEnd={handleMouseLeave}
         >
             <DropZone onDrop={(item: any) => {
                 if (item.type === 'station') {

--- a/src/pages/TripsPage.tsx
+++ b/src/pages/TripsPage.tsx
@@ -39,7 +39,7 @@ const RouteSlice: React.FC<{ segments: any[] }> = ({ segments }) => {
     const shouldRotate = isMobile && widthPx > maxWidth && maxWidth > 0;
 
     return (
-        <div ref={containerRef} className="shrink-0 ml-2 border-l border-gray-50 flex flex-row items-center justify-end pl-2 gap-2" style={{ minWidth: shouldRotate ? '40px' : '100px' }}>
+        <div ref={containerRef} className="absolute right-2 top-1/2 -translate-y-1/2 z-0 opacity-20 pointer-events-none flex flex-row items-center justify-end gap-2" style={{ minWidth: shouldRotate ? '40px' : '100px' }}>
             <div style={{ width: shouldRotate ? heightPx : widthPx, height: shouldRotate ? widthPx : heightPx, maxWidth: shouldRotate ? 'none' : '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
               <svg viewBox="0 0 100 50" preserveAspectRatio="none" className="opacity-80" style={{ width: widthPx, height: heightPx, transform: shouldRotate ? 'rotate(90deg)' : 'none', transformOrigin: 'center center' }}>
                   {visualPaths.map((item: any, idx: number) => (
@@ -47,7 +47,7 @@ const RouteSlice: React.FC<{ segments: any[] }> = ({ segments }) => {
                   ))}
               </svg>
             </div>
-            <div className="text-[10px] font-bold text-gray-400 shrink-0 text-right">{Math.round(totalDist)}km</div>
+            <div className="text-[10px] font-bold text-gray-800 shrink-0 text-right opacity-100">{Math.round(totalDist)}km</div>
         </div>
     );
 };
@@ -110,7 +110,7 @@ export const TripsPage: React.FC = () => {
     };
 
     return (
-        <div className="flex-1 flex flex-col overflow-y-auto p-4 space-y-3 pb-4">
+        <div className="flex-1 flex flex-col overflow-y-auto p-4 space-y-3 pb-4 h-full">
             {trips.length === 0 ? (
                 <div className="text-center text-gray-400 py-10 flex flex-col items-center justify-center flex-1">
                     <Train size={48} className="opacity-20 mb-4"/>
@@ -159,13 +159,8 @@ export const TripsPage: React.FC = () => {
                                         <button onClick={(e) => { e.stopPropagation(); handleDeleteTrip(t.id); }} className={cls.btnDel}><Trash2 size={14}/></button>
                                     </div>
                                 </div>
-<<<<<<< HEAD
                                 <div className="relative z-10 flex flex-row">
                                     <div className="flex-1 space-y-2 relative overflow-hidden">
-=======
-                                <div className="flex flex-row">
-                                    <div className="flex-1 space-y-2 relative">
->>>>>>> parent of 4585ee0 (fix: mobile viewport height and svg stretching layout)
                                         <div className="relative z-10 flex flex-col text-sm">
                                             <div className="flex items-center gap-2">
                                                 <MapPin size={14} className={`${cls.icon} shrink-0`}/>
@@ -191,13 +186,8 @@ export const TripsPage: React.FC = () => {
                                     <button onClick={(e) => { e.stopPropagation(); handleDeleteTrip(t.id); }} className="text-gray-400 hover:text-red-500"><Trash2 size={14}/></button>
                                 </div>
                             </div>
-<<<<<<< HEAD
                             <div className="relative z-10 flex flex-row">
                                 <div className="flex-1 space-y-2 relative overflow-hidden">
-=======
-                            <div className="flex flex-row">
-                                <div className="flex-1 space-y-2 relative">
->>>>>>> parent of 4585ee0 (fix: mobile viewport height and svg stretching layout)
                                     {segments.length > 1 && <div className="absolute left-[5px] top-2 bottom-2 w-0.5 bg-gray-200 z-0"></div>}
                                     {segments.map((seg, idx) => {
                                         const line = railwayData[seg.lineKey];

--- a/src/utils/suicaParser.ts
+++ b/src/utils/suicaParser.ts
@@ -1,5 +1,5 @@
 import { Trip, TripSegment, RailwayMap } from '../store';
-import { findRoute } from './railwayRouting';
+import { findRoute } from '../core/railwayRouting';
 
 export interface SuicaRow {
     no: string;


### PR DESCRIPTION
Improved the mobile layout specifically addressing the `dvh` usage and the RouteSlice/Trips list layout on mobile displays. This should prevent issues where the `add trips` empty state button was being hidden beneath the main scroll viewport and where SVG maps stretched the list items too far vertically.

---
*PR created automatically by Jules for task [5569493404979618142](https://jules.google.com/task/5569493404979618142) started by @OsakaLOOP*