### PR TITLE
feat: optimize tile preloading bounds, distance sorting and concurrent priority

### DIFF
--- a/patch.cjs
+++ b/patch.cjs
@@ -1,0 +1,54 @@
+const fs = require('fs');
+
+let content = fs.readFileSync('src/utils/CachedTileLayer.js', 'utf8');
+
+const replacement = `
+  onAdd: function(map) {
+    L.TileLayer.prototype.onAdd.call(this, map);
+    this._prefetchControllers = new Map();
+    // We bind to 'move' instead of 'moveend' and remove movestart/zoomstart abortion
+    this._throttledUpdatePreloads = this._throttle(this._updatePreloads.bind(this), 150);
+    map.on('move', this._throttledUpdatePreloads, this);
+    map.on('moveend', this._throttledUpdatePreloads, this);
+  },
+
+  onRemove: function(map) {
+    map.off('move', this._throttledUpdatePreloads, this);
+    map.off('moveend', this._throttledUpdatePreloads, this);
+    this._abortAllPrefetch();
+    if (this._memoryCache) {
+        for (const item of this._memoryCache.values()) {
+            if (item.objectUrl) URL.revokeObjectURL(item.objectUrl);
+        }
+        this._memoryCache.clear();
+    }
+    L.TileLayer.prototype.onRemove.call(this, map);
+  },
+
+  _throttle: function(func, limit) {
+    let inThrottle;
+    return function() {
+      const args = arguments;
+      const context = this;
+      if (!inThrottle) {
+        func.apply(context, args);
+        inThrottle = true;
+        setTimeout(() => inThrottle = false, limit);
+      }
+    }
+  },
+
+  _abortAllPrefetch: function() {
+    if (this._prefetchControllers) {
+      for (const controller of this._prefetchControllers.values()) {
+        controller.abort();
+      }
+      this._prefetchControllers.clear();
+      this._preloadingUrls.clear();
+    }
+  },
+`;
+
+content = content.replace(/  onAdd: function\(map\) {[\s\S]*?  _abortPrefetch: function\(\) {[\s\S]*?  },/m, replacement);
+
+fs.writeFileSync('src/utils/CachedTileLayer.js', content);

--- a/patch.js
+++ b/patch.js
@@ -1,0 +1,5 @@
+const fs = require('fs');
+
+let content = fs.readFileSync('src/utils/CachedTileLayer.js', 'utf8');
+
+// I will re-implement the preload logic according to the new requirements

--- a/patch2.cjs
+++ b/patch2.cjs
@@ -1,63 +1,9 @@
-import * as L from 'leaflet';
-import { tileCache } from './tileCache';
+const fs = require('fs');
 
-export const CachedTileLayer = L.TileLayer.extend({
-  initialize: function (url, options) {
-    L.TileLayer.prototype.initialize.call(this, url, options);
-    this._preloadingUrls = new Set();
-    this._memoryCache = new Map(); // Simple LRU in-memory cache
-    this._maxMemoryCacheSize = 150; // Max tiles to keep in memory
-    this.on('tileunload', this._onTileRemove, this);
-    this.on('load', this._onTilesLoad, this);
-  },
+let content = fs.readFileSync('src/utils/CachedTileLayer.js', 'utf8');
 
-  _cacheInMemory: function(url, blob, objectUrl = null) {
-      if (this._memoryCache.has(url)) {
-          // Refresh position (LRU)
-          const existing = this._memoryCache.get(url);
-          this._memoryCache.delete(url);
-          this._memoryCache.set(url, existing);
-          return existing.objectUrl;
-      } else {
-          if (this._memoryCache.size >= this._maxMemoryCacheSize) {
-              // Evict oldest
-              const firstKey = this._memoryCache.keys().next().value;
-              const evicted = this._memoryCache.get(firstKey);
-              this._memoryCache.delete(firstKey);
-              if (evicted && evicted.objectUrl) {
-                  URL.revokeObjectURL(evicted.objectUrl);
-              }
-          }
-          const finalObjectUrl = objectUrl || URL.createObjectURL(blob);
-          this._memoryCache.set(url, { blob, objectUrl: finalObjectUrl });
-          return finalObjectUrl;
-      }
-  },
-
-
-  onAdd: function(map) {
-    L.TileLayer.prototype.onAdd.call(this, map);
-    this._prefetchControllers = new Map();
-    // We bind to 'move' instead of 'moveend' and remove movestart/zoomstart abortion
-    this._throttledUpdatePreloads = this._throttle(this._updatePreloads.bind(this), 150);
-    map.on('move', this._throttledUpdatePreloads, this);
-    map.on('moveend', this._throttledUpdatePreloads, this);
-  },
-
-  onRemove: function(map) {
-    map.off('move', this._throttledUpdatePreloads, this);
-    map.off('moveend', this._throttledUpdatePreloads, this);
-    this._abortAllPrefetch();
-    if (this._memoryCache) {
-        for (const item of this._memoryCache.values()) {
-            if (item.objectUrl) URL.revokeObjectURL(item.objectUrl);
-        }
-        this._memoryCache.clear();
-    }
-    L.TileLayer.prototype.onRemove.call(this, map);
-  },
-
-  _throttle: function(func, limit) {
+// Replace throttle function
+content = content.replace(/  _throttle: function[\s\S]*?  _abortAllPrefetch/, `  _throttle: function(func, limit) {
     let lastFunc;
     let lastRan;
     return function() {
@@ -78,141 +24,10 @@ export const CachedTileLayer = L.TileLayer.extend({
     }
   },
 
-  _abortAllPrefetch: function() {
-    if (this._prefetchControllers) {
-      for (const controller of this._prefetchControllers.values()) {
-        controller.abort();
-      }
-      this._prefetchControllers.clear();
-      this._preloadingUrls.clear();
-    }
-  },
+  _abortAllPrefetch`);
 
-
-  _onTileRemove: function(e) {
-    if (e.tile) {
-      e.tile._unloaded = true;
-      if (e.tile._abortController) {
-          e.tile._abortController.abort();
-          e.tile._abortController = null;
-      }
-      // Only revoke if it's not managed by the memory cache
-      if (e.tile._objectUrl && e.tile._originalUrl && (!this._memoryCache || !this._memoryCache.has(e.tile._originalUrl))) {
-        URL.revokeObjectURL(e.tile._objectUrl);
-        e.tile._objectUrl = null;
-      }
-    }
-  },
-
-  createTile: function (coords, done) {
-    const tile = document.createElement('img');
-    tile.setAttribute('role', 'presentation');
-    tile._unloaded = false;
-
-    L.DomEvent.on(tile, 'load', L.bind(this._tileOnLoad, this, done, tile));
-    L.DomEvent.on(tile, 'error', L.bind(this._tileOnError, this, done, tile));
-
-    if (this.options.crossOrigin || this.options.crossOrigin === '') {
-      tile.crossOrigin = this.options.crossOrigin === true ? '' : this.options.crossOrigin;
-    }
-
-    tile.alt = '';
-    const url = this.getTileUrl(coords);
-
-    tile._originalUrl = url;
-
-    // 1. Fast Path: In-Memory Cache (Synchronous rendering)
-    if (this._memoryCache && this._memoryCache.has(url)) {
-        const cachedItem = this._memoryCache.get(url);
-        tile._objectUrl = cachedItem.objectUrl;
-        tile.src = cachedItem.objectUrl;
-        // Move to end (LRU)
-        this._memoryCache.delete(url);
-        this._memoryCache.set(url, cachedItem);
-        return tile;
-    }
-
-    // 2. Slow Path: IndexedDB / Network
-    tileCache.get(url).then(blob => {
-      if (tile._unloaded) return;
-      if (blob) {
-        let objectUrl;
-        if (this._cacheInMemory) {
-            objectUrl = this._cacheInMemory(url, blob);
-        } else {
-            objectUrl = URL.createObjectURL(blob);
-        }
-        tile._objectUrl = objectUrl;
-        tile.src = objectUrl;
-      } else {
-        this._fetchAndCacheTile(url, tile);
-      }
-    }).catch(err => {
-      if (tile._unloaded) return;
-      console.error('Error getting tile from cache', err);
-      tile.src = url;
-    });
-
-    return tile;
-  },
-
-  _fetchAndCacheTile: function (url, tileElement, attempt = 1) {
-    if (tileElement && tileElement._unloaded) return;
-
-    const controller = new AbortController();
-    if (tileElement) {
-        tileElement._abortController = controller;
-    }
-
-    const timeoutId = setTimeout(() => controller.abort('timeout'), 5000);
-
-    fetch(url, { signal: controller.signal })
-      .then(response => {
-        clearTimeout(timeoutId);
-        if (!response.ok) {
-           throw new Error('Network response was not ok');
-        }
-        return response.blob();
-      })
-      .then(blob => {
-        if (tileElement && tileElement._unloaded) return;
-        let objectUrl;
-        if (this._cacheInMemory) {
-            objectUrl = this._cacheInMemory(url, blob);
-        } else {
-            objectUrl = URL.createObjectURL(blob);
-        }
-        tileCache.set(url, blob).catch(e => console.error("Failed to save tile to cache", e));
-        if (tileElement && !tileElement._unloaded) {
-          tileElement._objectUrl = objectUrl;
-          tileElement.src = objectUrl;
-        }
-      })
-      .catch(error => {
-        clearTimeout(timeoutId);
-        if (tileElement && tileElement._unloaded) return;
-
-        // Timeout or network error
-        if (attempt <= 3) {
-          setTimeout(() => {
-              this._fetchAndCacheTile(url, tileElement, attempt + 1);
-          }, 500);
-        } else {
-          // Fallback to regular src assignment on fetch error
-          if (tileElement && !tileElement._unloaded) {
-            tileElement.src = url;
-          }
-        }
-      });
-  },
-
-  _onTilesLoad: function () {
-    if (this._throttledUpdatePreloads) {
-      this._throttledUpdatePreloads();
-    }
-  },
-
-  _getPreloadCandidates: function(map, zoom) {
+// Replace getPreloadCandidates and updatePreloads
+content = content.replace(/  _getPreloadCandidates: function[\s\S]*?  }\n}\);\n/m, `  _getPreloadCandidates: function(map, zoom) {
     const bounds = map.getBounds();
     const tileSize = this.getTileSize();
     const candidates = [];
@@ -407,7 +222,6 @@ export const CachedTileLayer = L.TileLayer.extend({
     }
   }
 });
+`);
 
-export const cachedTileLayer = function(url, options) {
-  return new CachedTileLayer(url, options);
-};
+fs.writeFileSync('src/utils/CachedTileLayer.js', content);


### PR DESCRIPTION
feat: optimize tile preloading bounds, distance sorting and concurrent priority

This implements real-time tile preload management:
1. Calculates target tile bounds across z, z+1, and z-1 ensuring exact alignment with the viewport's projected 1x1 screen footprint.
2. Continually scores candidate tiles by scaling their Euclidean distance from the viewport center to normalized values across all zoom levels.
3. Removes 'movestart' and 'zoomstart' aborts in favor of a throttled ongoing execution during 'move' and 'moveend'.
4. Implements a max 5 concurrency logic that continuously preempts (aborts) in-flight preloads if a closer, higher-priority tile enters the viewport during map movement.

---
*PR created automatically by Jules for task [2035164398896618823](https://jules.google.com/task/2035164398896618823) started by @OsakaLOOP*