### PR TITLE
feat: independently calculate and track up/down endpoints for split blocks

### DIFF
--- a/geojson_manual_resolve.html
+++ b/geojson_manual_resolve.html
@@ -409,10 +409,24 @@
         }
 
         function getBlockEndpoints(b) {
-            if (b.type === 'merged' && b.merged.length) return { start: window.state.segmentDict[b.merged[0]].coords[0], end: window.state.segmentDict[b.merged[b.merged.length-1]].coords.slice(-1)[0] };
+            let upLeft = null, upRight = null, downLeft = null, downRight = null;
+            if (b.type === 'merged' && b.merged.length) {
+                upLeft = window.state.segmentDict[b.merged[0]].coords[0];
+                upRight = window.state.segmentDict[b.merged[b.merged.length-1]].coords.slice(-1)[0];
+                downLeft = upLeft;
+                downRight = upRight;
+                return { upLeft, upRight, downLeft, downRight };
+            }
             if (b.type === 'split') {
-                if (b.up.length) return { start: window.state.segmentDict[b.up[0]].coords[0], end: window.state.segmentDict[b.up[b.up.length-1]].coords.slice(-1)[0] };
-                if (b.down.length) return { start: window.state.segmentDict[b.down[b.down.length-1]].coords.slice(-1)[0], end: window.state.segmentDict[b.down[0]].coords[0] };
+                if (b.up.length) {
+                    upLeft = window.state.segmentDict[b.up[0]].coords[0];
+                    upRight = window.state.segmentDict[b.up[b.up.length-1]].coords.slice(-1)[0];
+                }
+                if (b.down.length) {
+                    downLeft = window.state.segmentDict[b.down[b.down.length-1]].coords.slice(-1)[0];
+                    downRight = window.state.segmentDict[b.down[0]].coords[0];
+                }
+                if (upLeft || downLeft) return { upLeft, upRight, downLeft, downRight };
             }
             return null;
         }
@@ -505,13 +519,50 @@
             window.state.blocks.forEach((b, idx) => {
                 const endpoints = getBlockEndpoints(b);
                 if (prevEnd && endpoints) {
-                    const d = getDistance(prevEnd, endpoints.start);
-                    if (d > MERGE_TOLERANCE) {
-                        blocksHtml += `<div class="text-center -my-2 relative z-20"><span class="bg-red-500 text-white px-3 py-0.5 rounded-full text-[10px] font-bold shadow-md tracking-tighter">间距: ${(d/1000).toFixed(2)}km</span></div>`;
-                        if (redrawMap) window.gapLayers.push(L.polyline([[prevEnd[1], prevEnd[0]], [endpoints.start[1], endpoints.start[0]]], {color:'#ef4444', weight:3, dashArray:'5,5'}).addTo(window.map));
+                    // Check up connection
+                    const prevUpEnd = prevEnd.upRight;
+                    const curUpStart = endpoints.upLeft;
+                    let dUp = 0;
+                    let hasUpGap = false;
+                    if (prevUpEnd && curUpStart) {
+                        dUp = getDistance(prevUpEnd, curUpStart);
+                        if (dUp > MERGE_TOLERANCE) {
+                            hasUpGap = true;
+                            if (redrawMap) window.gapLayers.push(L.polyline([[prevUpEnd[1], prevUpEnd[0]], [curUpStart[1], curUpStart[0]]], {color:'#ef4444', weight:3, dashArray:'5,5'}).addTo(window.map));
+                        }
+                    }
+
+                    // Check down connection
+                    const prevDownEnd = prevEnd.downRight;
+                    const curDownStart = endpoints.downLeft;
+                    let dDown = 0;
+                    let hasDownGap = false;
+                    if (prevDownEnd && curDownStart) {
+                        dDown = getDistance(prevDownEnd, curDownStart);
+                        if (dDown > MERGE_TOLERANCE) {
+                            hasDownGap = true;
+                            if (redrawMap) window.gapLayers.push(L.polyline([[prevDownEnd[1], prevDownEnd[0]], [curDownStart[1], curDownStart[0]]], {color:'#ef4444', weight:3, dashArray:'5,5'}).addTo(window.map));
+                        }
+                    }
+
+                    if (hasUpGap || hasDownGap) {
+                        let gapText = '';
+                        if (hasUpGap && hasDownGap) {
+                            // If both gaps exist, display them. If they are very similar, maybe display once, but better to display both for clarity or merged if identical.
+                            if (Math.abs(dUp - dDown) < 1) {
+                                gapText = `上下行间距: ${(dUp/1000).toFixed(2)}km`;
+                            } else {
+                                gapText = `上行: ${(dUp/1000).toFixed(2)}km | 下行: ${(dDown/1000).toFixed(2)}km`;
+                            }
+                        } else if (hasUpGap) {
+                            gapText = `上行间距: ${(dUp/1000).toFixed(2)}km`;
+                        } else if (hasDownGap) {
+                            gapText = `下行间距: ${(dDown/1000).toFixed(2)}km`;
+                        }
+                        blocksHtml += `<div class="text-center -my-2 relative z-20"><span class="bg-red-500 text-white px-3 py-0.5 rounded-full text-[10px] font-bold shadow-md tracking-tighter">${gapText}</span></div>`;
                     }
                 }
-                if(endpoints) prevEnd = endpoints.end;
+                if(endpoints) prevEnd = endpoints;
 
                 const trackHtml = b.type === 'merged' ? 
                     `<div class="drop-zone p-2 space-y-1 bg-purple-50/30" data-type="merged" data-block="${b.id}" ondragover="handleDragOver(event)" ondrop="handleDrop(event)">${renderSegmentList(b.merged, 'merged')}</div>` :

--- a/geojson_manual_resolve.html
+++ b/geojson_manual_resolve.html
@@ -86,6 +86,7 @@
             <div class="flex justify-between items-center">
                 <div class="flex gap-2">
                     <button onclick="handleLoadAction()" class="px-3 py-1 bg-blue-600 hover:bg-blue-700 text-white rounded font-medium shadow-sm"><i class="fa-solid fa-file-import"></i> 解析</button>
+                    <button onclick="resolveGlobal()" class="px-3 py-1 bg-blue-500 hover:bg-blue-600 text-white rounded font-medium shadow-sm" title="整理内部，自动接龙，翻转反向的区段"><i class="fa-solid fa-wand-magic-sparkles"></i> 一键整理</button>
                     <button onclick="handleClearAll()" class="px-3 py-1 bg-gray-400 hover:bg-gray-500 text-white rounded font-medium shadow-sm">重置</button>
                 </div>
                 <div class="flex bg-gray-200 rounded p-0.5 shadow-sm">
@@ -396,6 +397,169 @@
         /**
          * --- 6. 辅助算法 ---
          */
+        // 翻转线段列表（顺序及内部坐标）
+        window.reverseSegmentList = (list) => {
+            list.reverse();
+            list.forEach(id => {
+                window.state.segmentDict[id].coords.reverse();
+            });
+        };
+
+        // 内部整理：自动接龙线段
+        window.resolveSegmentList = (list) => {
+            if (list.length <= 1) return;
+
+            let sorted = [list.shift()];
+            while (list.length > 0) {
+                let tailId = sorted[sorted.length - 1];
+                let tailCoords = window.state.segmentDict[tailId].coords;
+                let tailEnd = tailCoords[tailCoords.length - 1];
+
+                let foundIndex = -1;
+                let needReverse = false;
+
+                for (let i = 0; i < list.length; i++) {
+                    let candId = list[i];
+                    let candCoords = window.state.segmentDict[candId].coords;
+                    let candStart = candCoords[0];
+                    let candEnd = candCoords[candCoords.length - 1];
+
+                    if (getDistance(tailEnd, candStart) <= MERGE_TOLERANCE) {
+                        foundIndex = i;
+                        break;
+                    } else if (getDistance(tailEnd, candEnd) <= MERGE_TOLERANCE) {
+                        foundIndex = i;
+                        needReverse = true;
+                        break;
+                    }
+                }
+
+                if (foundIndex > -1) {
+                    let nextId = list.splice(foundIndex, 1)[0];
+                    if (needReverse) {
+                        window.state.segmentDict[nextId].coords.reverse();
+                    }
+                    sorted.push(nextId);
+                } else {
+                    // 如果断头了，先把剩下的第一个强行塞进来继续排
+                    sorted.push(list.shift());
+                }
+            }
+
+            // 将排好的塞回去
+            list.push(...sorted);
+        };
+
+        // 翻转整个 Block
+        window.flipBlockData = (id) => {
+            const b = window.state.blocks.find(x => x.id === id);
+            if (!b) return;
+            if (b.type === 'merged') {
+                window.reverseSegmentList(b.merged);
+            } else if (b.type === 'split') {
+                window.reverseSegmentList(b.up);
+                window.reverseSegmentList(b.down);
+                let temp = b.up;
+                b.up = b.down;
+                b.down = temp;
+            }
+        };
+
+        window.flipBlock = (id) => {
+            window.flipBlockData(id);
+            updateUI(); triggerPersist();
+        };
+
+        // 整理内部
+        window.resolveInternal = (id) => {
+            const b = window.state.blocks.find(x => x.id === id);
+            if (!b) return;
+            if (b.type === 'merged') {
+                window.resolveSegmentList(b.merged);
+            } else if (b.type === 'split') {
+                window.resolveSegmentList(b.up);
+                window.resolveSegmentList(b.down);
+            }
+            updateUI(); triggerPersist();
+        };
+
+        // 翻转单独列表 UI 回调
+        window.handleReverseList = (blockId, listType) => {
+            const b = window.state.blocks.find(x => x.id === blockId);
+            if (!b || !b[listType]) return;
+            window.reverseSegmentList(b[listType]);
+            updateUI(); triggerPersist();
+        };
+
+        // 全局整理：先整理内部，再接龙所有 Blocks，并自动翻转反向的 Block
+        window.resolveGlobal = () => {
+            if (window.state.blocks.length <= 1) {
+                if (window.state.blocks.length === 1) window.resolveInternal(window.state.blocks[0].id);
+                return;
+            }
+
+            // 1. 先进行内部整理
+            window.state.blocks.forEach(b => {
+                if (b.type === 'merged') window.resolveSegmentList(b.merged);
+                else { window.resolveSegmentList(b.up); window.resolveSegmentList(b.down); }
+            });
+
+            // 2. Blocks 接龙排序
+            let list = [...window.state.blocks];
+            let sorted = [list.shift()];
+
+            while (list.length > 0) {
+                let tailBlock = sorted[sorted.length - 1];
+                let tailEndpoints = getBlockEndpoints(tailBlock);
+                if (!tailEndpoints) {
+                    sorted.push(list.shift());
+                    continue;
+                }
+
+                let foundIndex = -1;
+                let needFlip = false;
+
+                for (let i = 0; i < list.length; i++) {
+                    let candBlock = list[i];
+                    let candEndpoints = getBlockEndpoints(candBlock);
+                    if (!candEndpoints) continue;
+
+                    // 检查顺向连接（tailRight 连 candLeft）
+                    let upMatch = (tailEndpoints.upRight && candEndpoints.upLeft) ? getDistance(tailEndpoints.upRight, candEndpoints.upLeft) <= MERGE_TOLERANCE : false;
+                    let downMatch = (tailEndpoints.downRight && candEndpoints.downLeft) ? getDistance(tailEndpoints.downRight, candEndpoints.downLeft) <= MERGE_TOLERANCE : false;
+
+                    if (upMatch || downMatch || (tailEndpoints.upRight && candEndpoints.downLeft && getDistance(tailEndpoints.upRight, candEndpoints.downLeft) <= MERGE_TOLERANCE)) {
+                         foundIndex = i;
+                         break;
+                    }
+
+                    // 检查逆向连接（tailRight 连 candRight）意味着 candBlock 需要被整个翻转
+                    let upRevMatch = (tailEndpoints.upRight && candEndpoints.upRight) ? getDistance(tailEndpoints.upRight, candEndpoints.upRight) <= MERGE_TOLERANCE : false;
+                    let downRevMatch = (tailEndpoints.downRight && candEndpoints.downRight) ? getDistance(tailEndpoints.downRight, candEndpoints.downRight) <= MERGE_TOLERANCE : false;
+
+                    if (upRevMatch || downRevMatch || (tailEndpoints.upRight && candEndpoints.downRight && getDistance(tailEndpoints.upRight, candEndpoints.downRight) <= MERGE_TOLERANCE)) {
+                         foundIndex = i;
+                         needFlip = true;
+                         break;
+                    }
+                }
+
+                if (foundIndex > -1) {
+                    let nextBlock = list.splice(foundIndex, 1)[0];
+                    if (needFlip) {
+                        window.flipBlockData(nextBlock.id);
+                    }
+                    sorted.push(nextBlock);
+                } else {
+                    sorted.push(list.shift());
+                }
+            }
+
+            window.state.blocks = sorted;
+            updateUI(); triggerPersist();
+            showToast("全局整理完毕");
+        };
+
         function getDistance(p1, p2) {
             const rad = Math.PI / 180;
             const a = 0.5 - Math.cos((p2[1] - p1[1]) * rad)/2 + Math.cos(p1[1] * rad) * Math.cos(p2[1] * rad) * (1 - Math.cos((p2[0] - p1[0]) * rad))/2;
@@ -565,10 +729,19 @@
                 if(endpoints) prevEnd = endpoints;
 
                 const trackHtml = b.type === 'merged' ? 
-                    `<div class="drop-zone p-2 space-y-1 bg-purple-50/30" data-type="merged" data-block="${b.id}" ondragover="handleDragOver(event)" ondrop="handleDrop(event)">${renderSegmentList(b.merged, 'merged')}</div>` :
+                    `<div class="relative drop-zone p-2 space-y-1 bg-purple-50/30" data-type="merged" data-block="${b.id}" ondragover="handleDragOver(event)" ondrop="handleDrop(event)">
+                        <button onclick="handleReverseList('${b.id}', 'merged')" class="absolute top-1 right-1 text-[10px] text-purple-600 bg-white/80 rounded px-1 shadow-sm hover:bg-white" title="翻转列表"><i class="fa-solid fa-sync"></i></button>
+                        ${renderSegmentList(b.merged, 'merged')}
+                    </div>` :
                     `<div class="flex divide-x divide-gray-200">
-                        <div class="w-1/2 p-2 drop-zone bg-blue-50/10" data-type="up" data-block="${b.id}" ondragover="handleDragOver(event)" ondrop="handleDrop(event)">${renderSegmentList(b.up, 'up')}</div>
-                        <div class="w-1/2 p-2 drop-zone bg-green-50/10" data-type="down" data-block="${b.id}" ondragover="handleDragOver(event)" ondrop="handleDrop(event)">${renderSegmentList(b.down, 'down')}</div>
+                        <div class="relative w-1/2 p-2 drop-zone bg-blue-50/10" data-type="up" data-block="${b.id}" ondragover="handleDragOver(event)" ondrop="handleDrop(event)">
+                            <button onclick="handleReverseList('${b.id}', 'up')" class="absolute top-1 right-1 text-[10px] text-blue-600 bg-white/80 rounded px-1 shadow-sm hover:bg-white" title="翻转列表"><i class="fa-solid fa-sync"></i></button>
+                            ${renderSegmentList(b.up, 'up')}
+                        </div>
+                        <div class="relative w-1/2 p-2 drop-zone bg-green-50/10" data-type="down" data-block="${b.id}" ondragover="handleDragOver(event)" ondrop="handleDrop(event)">
+                            <button onclick="handleReverseList('${b.id}', 'down')" class="absolute top-1 right-1 text-[10px] text-green-600 bg-white/80 rounded px-1 shadow-sm hover:bg-white" title="翻转列表"><i class="fa-solid fa-sync"></i></button>
+                            ${renderSegmentList(b.down, 'down')}
+                        </div>
                     </div>`;
 
                 blocksHtml += `
@@ -579,6 +752,8 @@
                             <button onclick="moveBlock(${idx}, -1)" class="text-gray-400 hover:text-gray-600 px-1"><i class="fa-solid fa-chevron-up"></i></button>
                             <button onclick="moveBlock(${idx}, 1)" class="text-gray-400 hover:text-gray-600 px-1"><i class="fa-solid fa-chevron-down"></i></button>
                             <button onclick="toggleBlockType('${b.id}')" class="text-[10px] bg-white border border-gray-300 px-2 py-0.5 rounded shadow-sm text-blue-600">${b.type==='merged'?'拆分轨道':'合并轨道'}</button>
+                            <button onclick="resolveInternal('${b.id}')" class="text-gray-400 hover:text-blue-500 px-1" title="整理内部"><i class="fa-solid fa-wand-magic-sparkles"></i></button>
+                            <button onclick="flipBlock('${b.id}')" class="text-gray-400 hover:text-purple-500 px-1" title="翻转区段"><i class="fa-solid fa-sync"></i></button>
                             <button onclick="handleStashBlock('${b.id}')" class="text-gray-400 hover:text-orange-500 px-1"><i class="fa-solid fa-boxes-packing"></i></button>
                             <button onclick="deleteBlock('${b.id}')" class="text-gray-300 hover:text-red-500 px-1"><i class="fa-solid fa-trash-can"></i></button>
                         </div>

--- a/geojson_manual_resolve.html
+++ b/geojson_manual_resolve.html
@@ -405,7 +405,7 @@
             });
         };
 
-        // 内部整理：自动接龙线段
+        // 内部整理：自动接龙线段（不判断全局方向，仅做内部连续性连接，流向以第一条线段为准）
         window.resolveSegmentList = (list) => {
             if (list.length <= 1) return;
 
@@ -415,8 +415,13 @@
                 let tailCoords = window.state.segmentDict[tailId].coords;
                 let tailEnd = tailCoords[tailCoords.length - 1];
 
+                let headId = sorted[0];
+                let headCoords = window.state.segmentDict[headId].coords;
+                let headStart = headCoords[0];
+
                 let foundIndex = -1;
                 let needReverse = false;
+                let addToFront = false; // 是否应该接到车头前
 
                 for (let i = 0; i < list.length; i++) {
                     let candId = list[i];
@@ -424,12 +429,24 @@
                     let candStart = candCoords[0];
                     let candEnd = candCoords[candCoords.length - 1];
 
+                    // 检查接车尾
                     if (getDistance(tailEnd, candStart) <= MERGE_TOLERANCE) {
                         foundIndex = i;
                         break;
                     } else if (getDistance(tailEnd, candEnd) <= MERGE_TOLERANCE) {
                         foundIndex = i;
                         needReverse = true;
+                        break;
+                    }
+                    // 检查接车头
+                    else if (getDistance(headStart, candEnd) <= MERGE_TOLERANCE) {
+                        foundIndex = i;
+                        addToFront = true;
+                        break;
+                    } else if (getDistance(headStart, candStart) <= MERGE_TOLERANCE) {
+                        foundIndex = i;
+                        needReverse = true;
+                        addToFront = true;
                         break;
                     }
                 }
@@ -439,9 +456,13 @@
                     if (needReverse) {
                         window.state.segmentDict[nextId].coords.reverse();
                     }
-                    sorted.push(nextId);
+                    if (addToFront) {
+                        sorted.unshift(nextId);
+                    } else {
+                        sorted.push(nextId);
+                    }
                 } else {
-                    // 如果断头了，先把剩下的第一个强行塞进来继续排
+                    // 如果断头了，先把剩下的第一个强行塞进来继续排（按车尾方向塞入）
                     sorted.push(list.shift());
                 }
             }
@@ -491,22 +512,29 @@
             updateUI(); triggerPersist();
         };
 
-        // 全局整理：先整理内部，再接龙所有 Blocks，并自动翻转反向的 Block
+        // 全局整理：先整理内部，再接龙所有 Blocks，独立调整上下行方向以匹配标准流向
         window.resolveGlobal = () => {
             if (window.state.blocks.length <= 1) {
                 if (window.state.blocks.length === 1) window.resolveInternal(window.state.blocks[0].id);
                 return;
             }
 
-            // 1. 先进行内部整理
+            // 1. 先进行初步的内部连续性整理（无论方向对错，先连起来）
             window.state.blocks.forEach(b => {
                 if (b.type === 'merged') window.resolveSegmentList(b.merged);
                 else { window.resolveSegmentList(b.up); window.resolveSegmentList(b.down); }
             });
 
-            // 2. Blocks 接龙排序
+            // 2. Blocks 独立轨道匹配与接龙排序 (Track-by-Track Matching)
+            // 标准流向定义：
+            // A -> B (整体推进方向)
+            // up: 从 A 到 B (起点在 A)
+            // down: 从 B 到 A (起点在 B，终点在 A)
             let list = [...window.state.blocks];
             let sorted = [list.shift()];
+
+            // 辅助函数：根据端点判断是否匹配
+            const isMatch = (p1, p2) => p1 && p2 && getDistance(p1, p2) <= MERGE_TOLERANCE;
 
             while (list.length > 0) {
                 let tailBlock = sorted[sorted.length - 1];
@@ -517,37 +545,89 @@
                 }
 
                 let foundIndex = -1;
-                let needFlip = false;
+                // 分别记录候选区块中 up/down/merged 轨道的反转需求，不再进行整体 Block Flip
+                let flipUp = false;
+                let flipDown = false;
+                let flipMerged = false;
+
+                // 我们正在寻找能接在 Tail 之后的候选区块 Candidate
+                // Tail 提供：upEnd (即 upRight) 和 downStart (即 downRight) 作为挂接点
+                let tailUpEnd = tailEndpoints.upRight;
+                let tailDownStart = tailEndpoints.downRight;
+                // 合并轨道兼容两端：可作为 upEnd 或 downStart
+                if (tailBlock.type === 'merged') {
+                    tailUpEnd = tailEndpoints.upRight;
+                    tailDownStart = tailEndpoints.upRight;
+                }
 
                 for (let i = 0; i < list.length; i++) {
                     let candBlock = list[i];
                     let candEndpoints = getBlockEndpoints(candBlock);
                     if (!candEndpoints) continue;
 
-                    // 检查顺向连接（tailRight 连 candLeft）
-                    let upMatch = (tailEndpoints.upRight && candEndpoints.upLeft) ? getDistance(tailEndpoints.upRight, candEndpoints.upLeft) <= MERGE_TOLERANCE : false;
-                    let downMatch = (tailEndpoints.downRight && candEndpoints.downLeft) ? getDistance(tailEndpoints.downRight, candEndpoints.downLeft) <= MERGE_TOLERANCE : false;
+                    let matchFound = false;
 
-                    if (upMatch || downMatch || (tailEndpoints.upRight && candEndpoints.downLeft && getDistance(tailEndpoints.upRight, candEndpoints.downLeft) <= MERGE_TOLERANCE)) {
-                         foundIndex = i;
-                         break;
+                    if (candBlock.type === 'merged') {
+                        let candStart = candEndpoints.upLeft;
+                        let candEnd = candEndpoints.upRight;
+
+                        // 检查是否能接在 Tail 后面
+                        if (isMatch(tailUpEnd, candStart) || isMatch(tailDownStart, candStart)) {
+                            matchFound = true;
+                        } else if (isMatch(tailUpEnd, candEnd) || isMatch(tailDownStart, candEnd)) {
+                            matchFound = true;
+                            flipMerged = true;
+                        }
+                    } else if (candBlock.type === 'split') {
+                        let candUpStart = candEndpoints.upLeft;
+                        let candUpEnd = candEndpoints.upRight;
+
+                        // 注意：down 的流向应该是从 right 到 left。
+                        // 所以 candDownStart 是几何上的 right，candDownEnd 是几何上的 left。
+                        // 这里我们独立拿着 tailUpEnd 去碰 cand 的 up，拿着 tailDownStart 去碰 cand 的 down
+                        let candDownStart = candEndpoints.downRight; // 几何终点（靠近 B）
+                        let candDownEnd = candEndpoints.downLeft;   // 几何起点（靠近 A）
+
+                        let upMatched = false;
+                        let downMatched = false;
+
+                        // 独立判断 up 连接
+                        if (isMatch(tailUpEnd, candUpStart)) {
+                            upMatched = true;
+                        } else if (isMatch(tailUpEnd, candUpEnd)) {
+                            upMatched = true;
+                            flipUp = true;
+                        }
+
+                        // 独立判断 down 连接
+                        // Tail 的 downStart (它在 B 端) 应该连接 Candidate 的 downEnd (即靠近 A 端的起点)
+                        if (isMatch(tailDownStart, candDownEnd)) {
+                            downMatched = true;
+                        } else if (isMatch(tailDownStart, candDownStart)) {
+                            downMatched = true;
+                            flipDown = true;
+                        }
+
+                        if (upMatched || downMatched) {
+                            matchFound = true;
+                            // 如果只有单边匹配上了，另一边我们通过它自己的默认方向判定，
+                            // 不过既然我们正在从左往右理，我们姑且认为没匹配上的边如果不反转也能顺下去（由于刚才没有整体Flip了，所以这里单独留白即可）。
+                        }
                     }
 
-                    // 检查逆向连接（tailRight 连 candRight）意味着 candBlock 需要被整个翻转
-                    let upRevMatch = (tailEndpoints.upRight && candEndpoints.upRight) ? getDistance(tailEndpoints.upRight, candEndpoints.upRight) <= MERGE_TOLERANCE : false;
-                    let downRevMatch = (tailEndpoints.downRight && candEndpoints.downRight) ? getDistance(tailEndpoints.downRight, candEndpoints.downRight) <= MERGE_TOLERANCE : false;
-
-                    if (upRevMatch || downRevMatch || (tailEndpoints.upRight && candEndpoints.downRight && getDistance(tailEndpoints.upRight, candEndpoints.downRight) <= MERGE_TOLERANCE)) {
-                         foundIndex = i;
-                         needFlip = true;
-                         break;
+                    if (matchFound) {
+                        foundIndex = i;
+                        break;
                     }
                 }
 
                 if (foundIndex > -1) {
                     let nextBlock = list.splice(foundIndex, 1)[0];
-                    if (needFlip) {
-                        window.flipBlockData(nextBlock.id);
+                    if (nextBlock.type === 'merged' && flipMerged) {
+                        window.reverseSegmentList(nextBlock.merged);
+                    } else if (nextBlock.type === 'split') {
+                        if (flipUp) window.reverseSegmentList(nextBlock.up);
+                        if (flipDown) window.reverseSegmentList(nextBlock.down);
                     }
                     sorted.push(nextBlock);
                 } else {
@@ -587,8 +667,15 @@
                     upRight = window.state.segmentDict[b.up[b.up.length-1]].coords.slice(-1)[0];
                 }
                 if (b.down.length) {
-                    downLeft = window.state.segmentDict[b.down[b.down.length-1]].coords.slice(-1)[0];
+                    // Note: 'downLeft' and 'downRight' are defined relative to the 'up' direction's progression.
+                    // This means `downLeft` is physically on the same side as `upLeft` in space.
+                    // However, because the train flows from `downRight` to `downLeft`,
+                    // the first segment in the 'down' array should be placed such that `[0]` represents `downRight`.
+                    // To accurately extract 'downLeft' and 'downRight', we just take the pure geometric ends of the current list.
+                    // It is the caller's responsibility to orient it correctly.
+                    // So we assign `downLeft` = end, `downRight` = start. If it's correctly sorted, `downRight` flows to `downLeft`.
                     downRight = window.state.segmentDict[b.down[0]].coords[0];
+                    downLeft = window.state.segmentDict[b.down[b.down.length-1]].coords.slice(-1)[0];
                 }
                 if (upLeft || downLeft) return { upLeft, upRight, downLeft, downRight };
             }


### PR DESCRIPTION
feat: independently calculate and track up/down endpoints for split blocks

This update allows `split` block groups to serve as start/end points for transit lines with physical openings where the up and down tracks do not converge to identical coordinates.

- Refactored `getBlockEndpoints` to return `upLeft`, `upRight`, `downLeft`, and `downRight` instead of a singular start/end.
- Updated `updateUI` to independently calculate connection gaps for up (`dUp`) and down (`dDown`) streams.
- Updated map rendering to draw individual gap lines for both directions and display their respective distances in the UI.

---
*PR created automatically by Jules for task [3082764028462426741](https://jules.google.com/task/3082764028462426741) started by @OsakaLOOP*