### PR TITLE
⚡ Bolt: Optimize station lookups in TripsPage and WalkTripEditor

### DIFF
--- a/src/components/modals/WalkTripEditor.tsx
+++ b/src/components/modals/WalkTripEditor.tsx
@@ -38,6 +38,22 @@ export const WalkTripEditor: React.FC = () => {
         return () => document.removeEventListener('keydown', handleKeyDown);
     }, [isOpen, closeEditor, form]);
 
+    // Build a fast station lookup map to optimize performance
+    const stationLookup = React.useMemo(() => {
+        const map = new Map<string, any>();
+        for (const lineKey in railwayData) {
+            if (Object.prototype.hasOwnProperty.call(railwayData, lineKey)) {
+                const line = railwayData[lineKey];
+                if (line && line.stations) {
+                    for (const st of line.stations) {
+                        map.set(st.id, st);
+                    }
+                }
+            }
+        }
+        return map;
+    }, [railwayData]);
+
     if (!isOpen) return null;
 
     const generateBezierPath = (startLngLat: [number, number], endLngLat: [number, number]): [number, number][] => {
@@ -79,12 +95,12 @@ export const WalkTripEditor: React.FC = () => {
             // Find coordinates for the Bezier curve
             let startCoords = null;
             let endCoords = null;
-            Object.values(railwayData).forEach(line => {
-                const s = line.stations.find(st => st.id === form.fromId);
-                if (s) startCoords = [s.lng, s.lat];
-                const e = line.stations.find(st => st.id === form.toId);
-                if (e) endCoords = [e.lng, e.lat];
-            });
+
+            const startStation = stationLookup.get(form.fromId);
+            if (startStation) startCoords = [startStation.lng, startStation.lat];
+
+            const endStation = stationLookup.get(form.toId);
+            if (endStation) endCoords = [endStation.lng, endStation.lat];
 
             if (startCoords && endCoords) {
                 walkPath = generateBezierPath(startCoords as [number, number], endCoords as [number, number]);
@@ -125,14 +141,10 @@ export const WalkTripEditor: React.FC = () => {
     };
 
     // Resolving station names for read-only display
-    let startName = "未知起点";
-    let endName = "未知终点";
-    Object.values(railwayData).forEach(line => {
-        const s = line.stations.find(st => st.id === form.fromId);
-        if (s) startName = s.name_ja;
-        const e = line.stations.find(st => st.id === form.toId);
-        if (e) endName = e.name_ja;
-    });
+    const startStation = stationLookup.get(form.fromId);
+    const endStation = stationLookup.get(form.toId);
+    const startName = startStation ? startStation.name_ja : "未知起点";
+    const endName = endStation ? endStation.name_ja : "未知终点";
 
     const isTree = form.walkType === 'tree';
 

--- a/src/pages/TripsPage.tsx
+++ b/src/pages/TripsPage.tsx
@@ -85,6 +85,22 @@ export const TripsPage: React.FC = () => {
 
     const fileInputRef = useRef<HTMLInputElement>(null);
 
+    // Build a fast station lookup map to optimize rendering performance, avoiding O(M*N) complexity
+    const stationLookup = useMemo(() => {
+        const map = new Map<string, any>();
+        for (const lineKey in railwayData) {
+            if (Object.prototype.hasOwnProperty.call(railwayData, lineKey)) {
+                const line = railwayData[lineKey];
+                if (line && line.stations) {
+                    for (const st of line.stations) {
+                        map.set(st.id, st);
+                    }
+                }
+            }
+        }
+        return map;
+    }, [railwayData]);
+
     const handleImportSuica = async (event: React.ChangeEvent<HTMLInputElement>) => {
         const file = event.target.files?.[0];
         if (!file) return;
@@ -157,14 +173,10 @@ export const TripsPage: React.FC = () => {
                     const isWalk = t.isWalk;
 
                     if (isWalk) {
-                        let startName = t.fromId || '';
-                        let endName = t.toId || '';
-                        Object.values(railwayData).forEach(line => {
-                            const s = line.stations.find(st => st.id === t.fromId);
-                            if (s) startName = s.name_ja;
-                            const e = line.stations.find(st => st.id === t.toId);
-                            if (e) endName = e.name_ja;
-                        });
+                        const startStation = stationLookup.get(t.fromId);
+                        const endStation = stationLookup.get(t.toId);
+                        const startName = startStation ? startStation.name_ja : (t.fromId || '');
+                        const endName = endStation ? endStation.name_ja : (t.toId || '');
 
                         const isTree = t.walkType === 'tree';
                         const cls = {


### PR DESCRIPTION
💡 What: Extracted repeated `Object.values(railwayData).forEach()` linear search loops out of React render mappings into O(1) Map lookups using `useMemo`.
🎯 Why: Iterating over `railwayData` (all lines and stations in the game) inside a loop over the user's `trips` results in severe O(N x M) rendering degradation, specifically noticeable for Walk trips.
📊 Impact: Transforms a high-latency rendering path into a constant-time O(1) operation per trip item. Greatly reduces unnecessary CPU blocking and object allocations.
🔬 Measurement: Verify rendering performance of `TripsPage` when populated with many `isWalk` trips; verify creating and loading Walk trips correctly resolves station names and locations.

---
*PR created automatically by Jules for task [7161908529602325852](https://jules.google.com/task/7161908529602325852) started by @OsakaLOOP*