### PR TITLE
fix: strictly show 2 loop line landmarks via

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.13.0",
     "remark-gfm": "^4.0.1",
+    "typescript": "^5.9.3",
     "zustand": "^5.0.11"
   },
   "devDependencies": {

--- a/src/core/railwayRouting.ts
+++ b/src/core/railwayRouting.ts
@@ -375,20 +375,23 @@ export const getLandmarks = (line: any, fromId: string, toId: string, loopVia?: 
     let checkedCount = 0;
     let currIdx = fi;
 
-    while (checkedCount < n && results.length < 3) {
+    while (checkedCount < n && results.length < 2) {
         if (direction === 'up') {
             currIdx = (currIdx + 1) % n;
         } else {
             currIdx = (currIdx - 1 + n) % n;
         }
 
-        // 如果到达终点，自然结束
-        if (currIdx === ti) break;
+        // 仅当非环线到达终点时才断开，环线为了收集 2 个 landmark 可以继续往后找
+        if (!line.meta?.isLoop && currIdx === ti) break;
+
         // 如果绕回起点（不应该发生，但作为安全兜底），结束
         if (currIdx === fi) break;
 
         if (stations[currIdx].landmark) {
-            results.push(stations[currIdx].name_ja);
+            if (!results.includes(stations[currIdx].name_ja)) {
+                results.push(stations[currIdx].name_ja);
+            }
         }
 
         checkedCount++;

--- a/src/workers/geo.worker.js
+++ b/src/workers/geo.worker.js
@@ -363,7 +363,7 @@ const getLandmarkVia = (line, fromId, toId, direction) => {
     let checkedCount = 0;
     let currIdx = fromIdx;
 
-    while (checkedCount < n && results.length < 3) {
+    while (checkedCount < n && results.length < 2) {
         // 按方向移动索引
         if (direction === 'up') {
             currIdx = (currIdx + 1) % n;
@@ -371,13 +371,16 @@ const getLandmarkVia = (line, fromId, toId, direction) => {
             currIdx = (currIdx - 1 + n) % n;
         }
 
-        // 如果到达终点，自然结束
-        if (currIdx === toIdx) break;
+        // 仅当非环线到达终点时才断开，环线为了收集 2 个 landmark 可以继续往后找
+        if (!isLoop && currIdx === toIdx) break;
+
         // 如果绕回起点
         if (currIdx === fromIdx) break;
 
         if (stations[currIdx].landmark) {
-            results.push(stations[currIdx].name_ja);
+            if (!results.includes(stations[currIdx].name_ja)) {
+                results.push(stations[currIdx].name_ja);
+            }
         }
 
         checkedCount++;


### PR DESCRIPTION
This pull request fixes an issue where the loop line landmark routing logic (`getLandmarkVia` / `getLandmarks`) might incorrectly show less than 2 landmarks if the destination station is reached early. 
The algorithm has been adjusted to look for exactly 2 landmarks and now properly allows loop lines to scan past the destination station if it has not met the quota.

---
*PR created automatically by Jules for task [18243333721086325590](https://jules.google.com/task/18243333721086325590) started by @OsakaLOOP*