### PR TITLE
⚡ Bolt: O(1) Station Name Lookup in TripsPage

### DIFF
--- a/src/pages/TripsPage.tsx
+++ b/src/pages/TripsPage.tsx
@@ -86,6 +86,22 @@ export const TripsPage: React.FC = () => {
     const addTrip = useStore(state => state.addTrip);
     const { saveData } = useUserData();
 
+    const stationNameMap = useMemo(() => {
+        const map = new Map<string, string>();
+        for (const lineKey in railwayData) {
+            if (Object.prototype.hasOwnProperty.call(railwayData, lineKey)) {
+                const line = railwayData[lineKey];
+                if (line.stations) {
+                    for (let i = 0; i < line.stations.length; i++) {
+                        const st = line.stations[i];
+                        map.set(st.id, st.name_ja);
+                    }
+                }
+            }
+        }
+        return map;
+    }, [railwayData]);
+
     const fileInputRef = useRef<HTMLInputElement>(null);
 
     const handleImportSuica = async (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -160,14 +176,8 @@ export const TripsPage: React.FC = () => {
                     const isWalk = t.isWalk;
 
                     if (isWalk) {
-                        let startName = t.fromId || '';
-                        let endName = t.toId || '';
-                        Object.values(railwayData).forEach(line => {
-                            const s = line.stations.find(st => st.id === t.fromId);
-                            if (s) startName = s.name_ja;
-                            const e = line.stations.find(st => st.id === t.toId);
-                            if (e) endName = e.name_ja;
-                        });
+                        const startName = (t.fromId && stationNameMap.get(t.fromId)) || t.fromId || '';
+                        const endName = (t.toId && stationNameMap.get(t.toId)) || t.toId || '';
 
                         const isTree = t.walkType === 'tree';
                         const cls = {
@@ -229,7 +239,7 @@ export const TripsPage: React.FC = () => {
                                     {segments.map((seg, idx) => {
                                         const line = railwayData[seg.lineKey];
                                         const icon = line?.meta?.icon;
-                                        const getSt = (id: string) => line?.stations.find(s => s.id === id)?.name_ja || id;
+                                        const getSt = (id: string) => (id && stationNameMap.get(id)) || id;
                                         return (
                                             <div key={idx} className="relative z-10 flex flex-col text-sm">
                                                 <div className="flex items-center gap-2">


### PR DESCRIPTION
💡 **What**: Added an O(1) `stationNameMap` using `useMemo` in `TripsPage.tsx` and refactored the station name rendering logic for both regular and walk trips to use this map instead of iterating arrays.
🎯 **Why**: Previously, on every render, the component would execute `Array.find` over nested lists of lines and stations. This becomes a severe bottleneck as the user accumulates more trips and more custom `railwayData` is imported.
📊 **Impact**: Reduces component re-render time by transforming O(N*M) rendering lookups into O(1) lookups.
🔬 **Measurement**: Verified the types and rendering logic using `npx tsc --noEmit` and manual logic review. No new dependencies were added.

---
*PR created automatically by Jules for task [7310510038377825847](https://jules.google.com/task/7310510038377825847) started by @OsakaLOOP*