### PR TITLE
feat(map): add LocateButton component and geolocation zoom cycling

### DIFF
--- a/src/AppLayout.tsx
+++ b/src/AppLayout.tsx
@@ -13,6 +13,7 @@ import { WalkTripEditor } from './components/modals/WalkTripEditor';
 import { MapContainer } from './components/map/MapContainer';
 import { PinEditor } from './components/map/PinEditor';
 import { FabButton } from './components/map/FabButton';
+import { LocateButton } from './components/map/LocateButton';
 import { Header } from './components/layout/Header';
 import { BottomNav } from './components/layout/BottomNav';
 import { TripsPage } from './pages/TripsPage';
@@ -1115,6 +1116,7 @@ export const AppLayout: React.FC = () => {
                     <div className={`flex-1 relative ${activeTab === 'map' ? 'block' : 'hidden'}`}>
                         <MapContainer setStationMenu={setStationMenu} isDraggingRef={isDraggingRef} />
                         <FabButton />
+                        <LocateButton />
                         <PinEditor />
                     </div>
                 </div>

--- a/src/components/map/LocateButton.tsx
+++ b/src/components/map/LocateButton.tsx
@@ -174,12 +174,19 @@ export const LocateButton: React.FC = () => {
       }
   };
 
+  const handlePointerLeave = () => {
+      if (pressTimerRef.current) {
+          clearTimeout(pressTimerRef.current);
+          pressTimerRef.current = null;
+      }
+  };
+
   return (
     <div className="absolute bottom-20 right-4 z-[400] flex flex-col gap-3">
       <button
         onPointerDown={handlePointerDown}
         onPointerUp={handlePointerUp}
-        onPointerLeave={handlePointerUp}
+        onPointerLeave={handlePointerLeave}
         onContextMenu={(e) => e.preventDefault()}
         disabled={status === "locating"}
         className={`p-3 rounded-full shadow-lg transition-all active:scale-95 flex items-center justify-center w-12 h-12

--- a/src/components/map/LocateButton.tsx
+++ b/src/components/map/LocateButton.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useRef, useEffect, useCallback } from "react";
 import { Locate, LocateFixed, Loader2 } from "lucide-react";
 import toast from "react-hot-toast";
+import { useTranslation } from "react-i18next";
+import { useStore } from "../../store";
 
 type LocateStatus = "idle" | "locating" | "located";
 const ZOOM_LEVELS = [14, 16, 18];
@@ -9,8 +11,11 @@ export const LocateButton: React.FC = () => {
   const [status, setStatus] = useState<LocateStatus>("idle");
   const [zoomIndex, setZoomIndex] = useState(0);
 
+  const { t } = useTranslation();
+
   const statusRef = useRef<LocateStatus>("idle");
   const coordsRef = useRef<{ lat: number; lng: number } | null>(null);
+  const pressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Keep refs in sync for event listeners
   useEffect(() => {
@@ -43,7 +48,7 @@ export const LocateButton: React.FC = () => {
       setZoomIndex(0);
 
       if (!navigator.geolocation) {
-        toast.error("浏览器不支持地理定位");
+        toast.error(t("map.geoNotSupported", "浏览器不支持地理定位"));
         setStatus("idle");
         return;
       }
@@ -64,11 +69,11 @@ export const LocateButton: React.FC = () => {
         },
         (error) => {
           console.error("Geolocation error:", error);
-          let errMsg = "定位获取失败";
-          if (error.code === error.PERMISSION_DENIED) errMsg = "定位权限被拒绝";
+          let errMsg = t("map.geoFail", "定位获取失败");
+          if (error.code === error.PERMISSION_DENIED) errMsg = t("map.geoDenied", "定位权限被拒绝");
           else if (error.code === error.POSITION_UNAVAILABLE)
-            errMsg = "无法获取位置信息";
-          else if (error.code === error.TIMEOUT) errMsg = "定位超时";
+            errMsg = t("map.geoUnavailable", "无法获取位置信息");
+          else if (error.code === error.TIMEOUT) errMsg = t("map.geoTimeout", "定位超时");
 
           toast.error(errMsg);
           setStatus("idle");
@@ -96,10 +101,86 @@ export const LocateButton: React.FC = () => {
     }
   };
 
+  const handleLongPress = () => {
+    if (status === "locating") return;
+
+    // Get the coords either from current ref if we have it, or fetch it right away
+    const executeAction = (lat: number, lng: number) => {
+        setStatus("located");
+        setZoomIndex(2); // Start at z18 since we are jumping to it
+
+        window.dispatchEvent(
+            new CustomEvent("map:fly-to-location", {
+                detail: { lat, lng, zoom: 18 },
+            }),
+        );
+
+        // Show station menus
+        import("../../core/railwayRouting").then(({ findNearbyStations }) => {
+            const railwayData = useStore.getState().railwayData;
+            const nearby = findNearbyStations(railwayData, lat, lng, 5);
+
+            if (nearby && nearby.length > 0) {
+                window.dispatchEvent(
+                    new CustomEvent("map:show-nearby-stations", {
+                        detail: { stations: nearby }
+                    })
+                );
+            }
+        });
+    };
+
+    if (coordsRef.current && status === "located") {
+        executeAction(coordsRef.current.lat, coordsRef.current.lng);
+    } else {
+        if (!navigator.geolocation) {
+            toast.error(t("map.geoNotSupported", "浏览器不支持地理定位"));
+            return;
+        }
+        setStatus("locating");
+        navigator.geolocation.getCurrentPosition(
+            (position) => {
+                const lat = position.coords.latitude;
+                const lng = position.coords.longitude;
+                coordsRef.current = { lat, lng };
+                executeAction(lat, lng);
+            },
+            (error) => {
+                let errMsg = t("map.geoFail", "定位获取失败");
+                if (error.code === error.PERMISSION_DENIED) errMsg = t("map.geoDenied", "定位权限被拒绝");
+                else if (error.code === error.POSITION_UNAVAILABLE) errMsg = t("map.geoUnavailable", "无法获取位置信息");
+                else if (error.code === error.TIMEOUT) errMsg = t("map.geoTimeout", "定位超时");
+                toast.error(errMsg);
+                setStatus("idle");
+            },
+            { enableHighAccuracy: true, timeout: 10000, maximumAge: 0 }
+        );
+    }
+  };
+
+  const handlePointerDown = () => {
+    if (pressTimerRef.current) clearTimeout(pressTimerRef.current);
+    pressTimerRef.current = setTimeout(() => {
+        pressTimerRef.current = null;
+        handleLongPress();
+    }, 600);
+  };
+
+  const handlePointerUp = () => {
+      if (pressTimerRef.current) {
+          clearTimeout(pressTimerRef.current);
+          pressTimerRef.current = null;
+          handleLocate();
+      }
+  };
+
   return (
     <div className="absolute bottom-20 right-4 z-[400] flex flex-col gap-3">
       <button
-        onClick={handleLocate}
+        onPointerDown={handlePointerDown}
+        onPointerUp={handlePointerUp}
+        onPointerLeave={handlePointerUp}
+        onContextMenu={(e) => e.preventDefault()}
         disabled={status === "locating"}
         className={`p-3 rounded-full shadow-lg transition-all active:scale-95 flex items-center justify-center w-12 h-12
                     ${

--- a/src/components/map/LocateButton.tsx
+++ b/src/components/map/LocateButton.tsx
@@ -1,0 +1,121 @@
+import React, { useState, useRef, useEffect, useCallback } from "react";
+import { Locate, LocateFixed, Loader2 } from "lucide-react";
+import toast from "react-hot-toast";
+
+type LocateStatus = "idle" | "locating" | "located";
+const ZOOM_LEVELS = [14, 16, 18];
+
+export const LocateButton: React.FC = () => {
+  const [status, setStatus] = useState<LocateStatus>("idle");
+  const [zoomIndex, setZoomIndex] = useState(0);
+
+  const statusRef = useRef<LocateStatus>("idle");
+  const coordsRef = useRef<{ lat: number; lng: number } | null>(null);
+
+  // Keep refs in sync for event listeners
+  useEffect(() => {
+    statusRef.current = status;
+  }, [status]);
+
+  const resetToIdle = useCallback(() => {
+    if (statusRef.current !== "idle") {
+      setStatus("idle");
+      setZoomIndex(0);
+    }
+  }, []);
+
+  useEffect(() => {
+    const handleUserInteraction = () => {
+      resetToIdle();
+    };
+
+    window.addEventListener("map:user-interaction", handleUserInteraction);
+    return () => {
+      window.removeEventListener("map:user-interaction", handleUserInteraction);
+    };
+  }, [resetToIdle]);
+
+  const handleLocate = () => {
+    if (status === "locating") return;
+
+    if (status === "idle") {
+      setStatus("locating");
+      setZoomIndex(0);
+
+      if (!navigator.geolocation) {
+        toast.error("浏览器不支持地理定位");
+        setStatus("idle");
+        return;
+      }
+
+      navigator.geolocation.getCurrentPosition(
+        (position) => {
+          const lat = position.coords.latitude;
+          const lng = position.coords.longitude;
+          coordsRef.current = { lat, lng };
+
+          setStatus("located");
+          // Fly to location with first zoom level (14)
+          window.dispatchEvent(
+            new CustomEvent("map:fly-to-location", {
+              detail: { lat, lng, zoom: ZOOM_LEVELS[0] },
+            }),
+          );
+        },
+        (error) => {
+          console.error("Geolocation error:", error);
+          let errMsg = "定位获取失败";
+          if (error.code === error.PERMISSION_DENIED) errMsg = "定位权限被拒绝";
+          else if (error.code === error.POSITION_UNAVAILABLE)
+            errMsg = "无法获取位置信息";
+          else if (error.code === error.TIMEOUT) errMsg = "定位超时";
+
+          toast.error(errMsg);
+          setStatus("idle");
+        },
+        {
+          enableHighAccuracy: true,
+          timeout: 10000,
+          maximumAge: 0,
+        },
+      );
+    } else if (status === "located" && coordsRef.current) {
+      // Cycle through zooms
+      const nextIndex = (zoomIndex + 1) % ZOOM_LEVELS.length;
+      setZoomIndex(nextIndex);
+
+      window.dispatchEvent(
+        new CustomEvent("map:fly-to-location", {
+          detail: {
+            lat: coordsRef.current.lat,
+            lng: coordsRef.current.lng,
+            zoom: ZOOM_LEVELS[nextIndex],
+          },
+        }),
+      );
+    }
+  };
+
+  return (
+    <div className="absolute bottom-20 right-4 z-[400] flex flex-col gap-3">
+      <button
+        onClick={handleLocate}
+        disabled={status === "locating"}
+        className={`p-3 rounded-full shadow-lg transition-all active:scale-95 flex items-center justify-center w-12 h-12
+                    ${
+                      status === "idle"
+                        ? "bg-white text-gray-700 hover:bg-gray-50"
+                        : status === "locating"
+                          ? "bg-white text-blue-500 cursor-not-allowed"
+                          : "bg-blue-500 text-white"
+                    }`}
+      >
+        {status === "idle" && <Locate size={24} />}
+        {status === "locating" && (
+          <Loader2 size={24} className="animate-spin" />
+        )}
+        {status === "located" && <LocateFixed size={24} />}
+      </button>
+    </div>
+  );
+};

--- a/src/components/map/LocateButton.tsx
+++ b/src/components/map/LocateButton.tsx
@@ -181,12 +181,21 @@ export const LocateButton: React.FC = () => {
       }
   };
 
+  // Mobile specific wrappers to handle touch gestures better
+  const eventProps = isMobile ? {
+      onTouchStart: handlePointerDown,
+      onTouchEnd: handlePointerUp,
+      onTouchCancel: handlePointerLeave
+  } : {
+      onPointerDown: handlePointerDown,
+      onPointerUp: handlePointerUp,
+      onPointerLeave: handlePointerLeave
+  };
+
   return (
     <div className="absolute bottom-20 right-4 z-[400] flex flex-col gap-3">
       <button
-        onPointerDown={handlePointerDown}
-        onPointerUp={handlePointerUp}
-        onPointerLeave={handlePointerLeave}
+        {...eventProps}
         onContextMenu={(e) => e.preventDefault()}
         disabled={status === "locating"}
         className={`p-3 rounded-full shadow-lg transition-all active:scale-95 flex items-center justify-center w-12 h-12

--- a/src/components/map/LocateButton.tsx.patch
+++ b/src/components/map/LocateButton.tsx.patch
@@ -1,0 +1,138 @@
+--- src/components/map/LocateButton.tsx
++++ src/components/map/LocateButton.tsx
+@@ -1,7 +1,9 @@
+ import React, { useState, useRef, useEffect, useCallback } from "react";
+ import { Locate, LocateFixed, Loader2 } from "lucide-react";
+ import toast from "react-hot-toast";
++import { useTranslation } from "react-i18next";
++import { useStore } from "../../store";
+
+ type LocateStatus = "idle" | "locating" | "located";
+ const ZOOM_LEVELS = [14, 16, 18];
+
+ export const LocateButton: React.FC = () => {
+   const [status, setStatus] = useState<LocateStatus>("idle");
+   const [zoomIndex, setZoomIndex] = useState(0);
++  const { t } = useTranslation();
+
+   const statusRef = useRef<LocateStatus>("idle");
+   const coordsRef = useRef<{ lat: number; lng: number } | null>(null);
++  const pressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+   // Keep refs in sync for event listeners
+   useEffect(() => {
+@@ -43,7 +46,7 @@
+       setZoomIndex(0);
+
+       if (!navigator.geolocation) {
+-        toast.error("浏览器不支持地理定位");
++        toast.error(t("map.geoNotSupported", "浏览器不支持地理定位"));
+         setStatus("idle");
+         return;
+       }
+@@ -66,11 +69,11 @@
+         (error) => {
+           console.error("Geolocation error:", error);
+-          let errMsg = "定位获取失败";
+-          if (error.code === error.PERMISSION_DENIED) errMsg = "定位权限被拒绝";
++          let errMsg = t("map.geoFail", "定位获取失败");
++          if (error.code === error.PERMISSION_DENIED) errMsg = t("map.geoDenied", "定位权限被拒绝");
+           else if (error.code === error.POSITION_UNAVAILABLE)
+-            errMsg = "无法获取位置信息";
+-          else if (error.code === error.TIMEOUT) errMsg = "定位超时";
++            errMsg = t("map.geoUnavailable", "无法获取位置信息");
++          else if (error.code === error.TIMEOUT) errMsg = t("map.geoTimeout", "定位超时");
+
+           toast.error(errMsg);
+           setStatus("idle");
+@@ -99,10 +102,87 @@
+     }
+   };
+
++  const handleLongPress = () => {
++    if (status === "locating") return;
++
++    // Get the coords either from current ref if we have it, or fetch it right away
++    const executeAction = (lat: number, lng: number) => {
++        setStatus("located");
++        setZoomIndex(2); // Start at z18 since we are jumping to it
++
++        window.dispatchEvent(
++            new CustomEvent("map:fly-to-location", {
++                detail: { lat, lng, zoom: 18 },
++            }),
++        );
++
++        // Show station menus
++        import("../../core/railwayRouting").then(({ findNearbyStations }) => {
++            const railwayData = useStore.getState().railwayData;
++            const nearby = findNearbyStations(railwayData, lat, lng, 5);
++
++            // Use the map dispatch to open station menus, assuming map instance can handle multiple or we use the custom event
++            if (nearby && nearby.length > 0) {
++                // We can just open the closest one for now via setStationMenu, or trigger an event for MapContainer to show them
++                // Or dispatch to AppLayout to open the nearest one
++                window.dispatchEvent(
++                    new CustomEvent("map:show-nearby-stations", {
++                        detail: { stations: nearby }
++                    })
++                );
++            }
++        });
++    };
++
++    if (coordsRef.current && status === "located") {
++        executeAction(coordsRef.current.lat, coordsRef.current.lng);
++    } else {
++        if (!navigator.geolocation) {
++            toast.error(t("map.geoNotSupported", "浏览器不支持地理定位"));
++            return;
++        }
++        setStatus("locating");
++        navigator.geolocation.getCurrentPosition(
++            (position) => {
++                const lat = position.coords.latitude;
++                const lng = position.coords.longitude;
++                coordsRef.current = { lat, lng };
++                executeAction(lat, lng);
++            },
++            (error) => {
++                let errMsg = t("map.geoFail", "定位获取失败");
++                if (error.code === error.PERMISSION_DENIED) errMsg = t("map.geoDenied", "定位权限被拒绝");
++                else if (error.code === error.POSITION_UNAVAILABLE) errMsg = t("map.geoUnavailable", "无法获取位置信息");
++                else if (error.code === error.TIMEOUT) errMsg = t("map.geoTimeout", "定位超时");
++                toast.error(errMsg);
++                setStatus("idle");
++            },
++            { enableHighAccuracy: true, timeout: 10000, maximumAge: 0 }
++        );
++    }
++  };
++
++  const handlePointerDown = () => {
++    if (pressTimerRef.current) clearTimeout(pressTimerRef.current);
++    pressTimerRef.current = setTimeout(() => {
++        pressTimerRef.current = null;
++        handleLongPress();
++    }, 600);
++  };
++
++  const handlePointerUp = () => {
++      if (pressTimerRef.current) {
++          clearTimeout(pressTimerRef.current);
++          pressTimerRef.current = null;
++          handleLocate();
++      }
++  };
++
+   return (
+     <div className="absolute bottom-20 right-4 z-[400] flex flex-col gap-3">
+       <button
+-        onClick={handleLocate}
++        onPointerDown={handlePointerDown}
++        onPointerUp={handlePointerUp}
++        onPointerLeave={handlePointerUp}
++        onContextMenu={(e) => e.preventDefault()}
+         disabled={status === "locating"}
+         className={`p-3 rounded-full shadow-lg transition-all active:scale-95 flex items-center justify-center w-12 h-12
+                     ${

--- a/src/components/map/LocateButton.tsx.patch
+++ b/src/components/map/LocateButton.tsx.patch
@@ -1,138 +1,44 @@
 --- src/components/map/LocateButton.tsx
 +++ src/components/map/LocateButton.tsx
-@@ -1,7 +1,9 @@
- import React, { useState, useRef, useEffect, useCallback } from "react";
- import { Locate, LocateFixed, Loader2 } from "lucide-react";
+@@ -3,6 +3,7 @@
  import toast from "react-hot-toast";
-+import { useTranslation } from "react-i18next";
-+import { useStore } from "../../store";
+ import { useTranslation } from "react-i18next";
+ import { useStore } from "../../store";
++import { isMobile } from 'react-device-detect';
 
  type LocateStatus = "idle" | "locating" | "located";
  const ZOOM_LEVELS = [14, 16, 18];
-
- export const LocateButton: React.FC = () => {
-   const [status, setStatus] = useState<LocateStatus>("idle");
-   const [zoomIndex, setZoomIndex] = useState(0);
-+  const { t } = useTranslation();
-
-   const statusRef = useRef<LocateStatus>("idle");
-   const coordsRef = useRef<{ lat: number; lng: number } | null>(null);
-+  const pressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-   // Keep refs in sync for event listeners
-   useEffect(() => {
-@@ -43,7 +46,7 @@
-       setZoomIndex(0);
-
-       if (!navigator.geolocation) {
--        toast.error("浏览器不支持地理定位");
-+        toast.error(t("map.geoNotSupported", "浏览器不支持地理定位"));
-         setStatus("idle");
-         return;
-       }
-@@ -66,11 +69,11 @@
-         (error) => {
-           console.error("Geolocation error:", error);
--          let errMsg = "定位获取失败";
--          if (error.code === error.PERMISSION_DENIED) errMsg = "定位权限被拒绝";
-+          let errMsg = t("map.geoFail", "定位获取失败");
-+          if (error.code === error.PERMISSION_DENIED) errMsg = t("map.geoDenied", "定位权限被拒绝");
-           else if (error.code === error.POSITION_UNAVAILABLE)
--            errMsg = "无法获取位置信息";
--          else if (error.code === error.TIMEOUT) errMsg = "定位超时";
-+            errMsg = t("map.geoUnavailable", "无法获取位置信息");
-+          else if (error.code === error.TIMEOUT) errMsg = t("map.geoTimeout", "定位超时");
-
-           toast.error(errMsg);
-           setStatus("idle");
-@@ -99,10 +102,87 @@
-     }
+@@ -165,7 +166,7 @@
+     pressTimerRef.current = setTimeout(() => {
+         pressTimerRef.current = null;
+         handleLongPress();
+-    }, 600);
++    }, isMobile ? 800 : 600); // Slightly longer on mobile to avoid accidental long presses when trying to tap quickly
    };
 
-+  const handleLongPress = () => {
-+    if (status === "locating") return;
-+
-+    // Get the coords either from current ref if we have it, or fetch it right away
-+    const executeAction = (lat: number, lng: number) => {
-+        setStatus("located");
-+        setZoomIndex(2); // Start at z18 since we are jumping to it
-+
-+        window.dispatchEvent(
-+            new CustomEvent("map:fly-to-location", {
-+                detail: { lat, lng, zoom: 18 },
-+            }),
-+        );
-+
-+        // Show station menus
-+        import("../../core/railwayRouting").then(({ findNearbyStations }) => {
-+            const railwayData = useStore.getState().railwayData;
-+            const nearby = findNearbyStations(railwayData, lat, lng, 5);
-+
-+            // Use the map dispatch to open station menus, assuming map instance can handle multiple or we use the custom event
-+            if (nearby && nearby.length > 0) {
-+                // We can just open the closest one for now via setStationMenu, or trigger an event for MapContainer to show them
-+                // Or dispatch to AppLayout to open the nearest one
-+                window.dispatchEvent(
-+                    new CustomEvent("map:show-nearby-stations", {
-+                        detail: { stations: nearby }
-+                    })
-+                );
-+            }
-+        });
-+    };
-+
-+    if (coordsRef.current && status === "located") {
-+        executeAction(coordsRef.current.lat, coordsRef.current.lng);
-+    } else {
-+        if (!navigator.geolocation) {
-+            toast.error(t("map.geoNotSupported", "浏览器不支持地理定位"));
-+            return;
-+        }
-+        setStatus("locating");
-+        navigator.geolocation.getCurrentPosition(
-+            (position) => {
-+                const lat = position.coords.latitude;
-+                const lng = position.coords.longitude;
-+                coordsRef.current = { lat, lng };
-+                executeAction(lat, lng);
-+            },
-+            (error) => {
-+                let errMsg = t("map.geoFail", "定位获取失败");
-+                if (error.code === error.PERMISSION_DENIED) errMsg = t("map.geoDenied", "定位权限被拒绝");
-+                else if (error.code === error.POSITION_UNAVAILABLE) errMsg = t("map.geoUnavailable", "无法获取位置信息");
-+                else if (error.code === error.TIMEOUT) errMsg = t("map.geoTimeout", "定位超时");
-+                toast.error(errMsg);
-+                setStatus("idle");
-+            },
-+            { enableHighAccuracy: true, timeout: 10000, maximumAge: 0 }
-+        );
-+    }
-+  };
-+
-+  const handlePointerDown = () => {
-+    if (pressTimerRef.current) clearTimeout(pressTimerRef.current);
-+    pressTimerRef.current = setTimeout(() => {
-+        pressTimerRef.current = null;
-+        handleLongPress();
-+    }, 600);
-+  };
-+
-+  const handlePointerUp = () => {
-+      if (pressTimerRef.current) {
-+          clearTimeout(pressTimerRef.current);
-+          pressTimerRef.current = null;
-+          handleLocate();
-+      }
+   const handlePointerUp = () => {
+@@ -183,12 +184,20 @@
+       }
+   };
+
++  // Mobile specific wrappers to handle touch gestures better
++  const eventProps = isMobile ? {
++      onTouchStart: handlePointerDown,
++      onTouchEnd: handlePointerUp,
++      onTouchCancel: handlePointerLeave
++  } : {
++      onPointerDown: handlePointerDown,
++      onPointerUp: handlePointerUp,
++      onPointerLeave: handlePointerLeave
 +  };
 +
    return (
      <div className="absolute bottom-20 right-4 z-[400] flex flex-col gap-3">
        <button
--        onClick={handleLocate}
-+        onPointerDown={handlePointerDown}
-+        onPointerUp={handlePointerUp}
-+        onPointerLeave={handlePointerUp}
-+        onContextMenu={(e) => e.preventDefault()}
+-        onPointerDown={handlePointerDown}
+-        onPointerUp={handlePointerUp}
+-        onPointerLeave={handlePointerLeave}
++        {...eventProps}
+         onContextMenu={(e) => e.preventDefault()}
          disabled={status === "locating"}
          className={`p-3 rounded-full shadow-lg transition-all active:scale-95 flex items-center justify-center w-12 h-12
-                     ${

--- a/src/components/map/MapContainer.tsx
+++ b/src/components/map/MapContainer.tsx
@@ -1,341 +1,495 @@
-import React, { useEffect, useRef } from 'react';
-import * as L from 'leaflet';
-import 'leaflet/dist/leaflet.css';
-import { useStore, PinMode, StationMenuData, CustomFeatureCollection, CustomGeoJSONFeature } from '../../store';
-import { findNearestPointOnLine } from '../../core/railwayRouting';
-import { syncLeafletLayerGroup } from '../../utils/leafletSync';
-import { cachedTileLayer } from '../../utils/CachedTileLayer';
-import { useShallow } from 'zustand/react/shallow';
-import toast from 'react-hot-toast';
+import React, { useEffect, useRef } from "react";
+import * as L from "leaflet";
+import "leaflet/dist/leaflet.css";
+import {
+  useStore,
+  PinMode,
+  StationMenuData,
+  CustomFeatureCollection,
+  CustomGeoJSONFeature,
+} from "../../store";
+import { findNearestPointOnLine } from "../../core/railwayRouting";
+import { syncLeafletLayerGroup } from "../../utils/leafletSync";
+import { cachedTileLayer } from "../../utils/CachedTileLayer";
+import { useShallow } from "zustand/react/shallow";
+import toast from "react-hot-toast";
 
 // 记录各域名最后一次报错的时间，用于节流
 const lastTileErrorTime: Record<string, number> = {};
 
 interface Props {
-    setStationMenu: (menu: StationMenuData | null) => void;
-    isDraggingRef: React.MutableRefObject<boolean>;
+  setStationMenu: (menu: StationMenuData | null) => void;
+  isDraggingRef: React.MutableRefObject<boolean>;
 }
 
-export const MapContainer: React.FC<Props> = ({ setStationMenu, isDraggingRef }) => {
-    const mapRef = useRef<HTMLDivElement>(null);
-    const mapInstance = useRef<L.Map | null>(null);
-    const pinsLayer = useRef<L.LayerGroup | null>(null);
-    const baseLinesLayer = useRef<L.LayerGroup | null>(null);
-    const baseStationsLayer = useRef<L.LayerGroup | null>(null);
-    const geoDataRef = useRef<CustomFeatureCollection | null>(null);
-    const visitedStationsRef = useRef<Set<string>>(new Set());
-    const routeLayer = useRef<L.LayerGroup | null>(null);
-    const railLayerRef = useRef<L.TileLayer | null>(null);
-    const rubberBandLayerRef = useRef<L.LayerGroup | null>(null);
+export const MapContainer: React.FC<Props> = ({
+  setStationMenu,
+  isDraggingRef,
+}) => {
+  const mapRef = useRef<HTMLDivElement>(null);
+  const mapInstance = useRef<L.Map | null>(null);
+  const pinsLayer = useRef<L.LayerGroup | null>(null);
+  const baseLinesLayer = useRef<L.LayerGroup | null>(null);
+  const baseStationsLayer = useRef<L.LayerGroup | null>(null);
+  const geoDataRef = useRef<CustomFeatureCollection | null>(null);
+  const visitedStationsRef = useRef<Set<string>>(new Set());
+  const routeLayer = useRef<L.LayerGroup | null>(null);
+  const railLayerRef = useRef<L.TileLayer | null>(null);
+  const rubberBandLayerRef = useRef<L.LayerGroup | null>(null);
 
-    // Explicit SVG Renderers for pointer-events passthrough
-    const baseLinesRendererRef = useRef<L.Renderer | null>(null);
-    const baseStationsRendererRef = useRef<L.Renderer | null>(null);
-    const routeRendererRef = useRef<L.Renderer | null>(null);
-    const visitedStationsRendererRef = useRef<L.Renderer | null>(null);
+  // Explicit SVG Renderers for pointer-events passthrough
+  const baseLinesRendererRef = useRef<L.Renderer | null>(null);
+  const baseStationsRendererRef = useRef<L.Renderer | null>(null);
+  const routeRendererRef = useRef<L.Renderer | null>(null);
+  const visitedStationsRendererRef = useRef<L.Renderer | null>(null);
 
-    // For local long-press routing drag
-    const pressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-    const routeDragRef = useRef<{ active: boolean, startStation: CustomGeoJSONFeature | null, currentSnap: CustomGeoJSONFeature | null, rubberLine: L.Polyline | null, snapCircleCenter: L.CircleMarker | null, openedTooltips: Set<L.Layer> }>({ active: false, startStation: null, currentSnap: null, rubberLine: null, snapCircleCenter: null, openedTooltips: new Set() });
-    const wasDraggingRef = useRef(false);
+  // For local long-press routing drag
+  const pressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const routeDragRef = useRef<{
+    active: boolean;
+    startStation: CustomGeoJSONFeature | null;
+    currentSnap: CustomGeoJSONFeature | null;
+    rubberLine: L.Polyline | null;
+    snapCircleCenter: L.CircleMarker | null;
+    openedTooltips: Set<L.Layer>;
+  }>({
+    active: false,
+    startStation: null,
+    currentSnap: null,
+    rubberLine: null,
+    snapCircleCenter: null,
+    openedTooltips: new Set(),
+  });
+  const wasDraggingRef = useRef(false);
 
-    const [isMapInitialized, setIsMapInitialized] = React.useState(false);
+  const [isMapInitialized, setIsMapInitialized] = React.useState(false);
 
-    const animateRubberRetract = (polyline: L.Polyline, startLatLng: L.LatLng, endLatLng: L.LatLng, duration = 450) => {
-        const dx = endLatLng.lng - startLatLng.lng;
-        const dy = endLatLng.lat - startLatLng.lat;
-        const startTime = performance.now();
-        const jitterX = (Math.random() - 0.5) * 0.03 * Math.abs(dx || 1);
-        const jitterY = (Math.random() - 0.5) * 0.03 * Math.abs(dy || 1);
+  const animateRubberRetract = (
+    polyline: L.Polyline,
+    startLatLng: L.LatLng,
+    endLatLng: L.LatLng,
+    duration = 450,
+  ) => {
+    const dx = endLatLng.lng - startLatLng.lng;
+    const dy = endLatLng.lat - startLatLng.lat;
+    const startTime = performance.now();
+    const jitterX = (Math.random() - 0.5) * 0.03 * Math.abs(dx || 1);
+    const jitterY = (Math.random() - 0.5) * 0.03 * Math.abs(dy || 1);
 
-        const step = (timestamp: number) => {
-            const elapsed = timestamp - startTime;
-            const t = Math.min(1, elapsed / duration);
-            const ease = 1 - Math.pow(1 - t, 3);
-            const wobble = Math.sin(t * Math.PI * 4) * (1 - t) * 0.18;
-            const currentT = Math.max(0, Math.min(1, 1 - ease + wobble));
-            const currentLng = startLatLng.lng + dx * currentT + jitterX * (1 - t);
-            const currentLat = startLatLng.lat + dy * currentT + jitterY * (1 - t);
-            polyline.setLatLngs([[startLatLng.lat, startLatLng.lng], [currentLat, currentLng]]);
-            if (t < 1) {
-                requestAnimationFrame(step);
-            }
-        };
-
+    const step = (timestamp: number) => {
+      const elapsed = timestamp - startTime;
+      const t = Math.min(1, elapsed / duration);
+      const ease = 1 - Math.pow(1 - t, 3);
+      const wobble = Math.sin(t * Math.PI * 4) * (1 - t) * 0.18;
+      const currentT = Math.max(0, Math.min(1, 1 - ease + wobble));
+      const currentLng = startLatLng.lng + dx * currentT + jitterX * (1 - t);
+      const currentLat = startLatLng.lat + dy * currentT + jitterY * (1 - t);
+      polyline.setLatLngs([
+        [startLatLng.lat, startLatLng.lng],
+        [currentLat, currentLng],
+      ]);
+      if (t < 1) {
         requestAnimationFrame(step);
+      }
     };
 
-    const {
-        geoData, leafletReady, tripSegmentsGeometry, activeTab, mapZoom,
-        setMapZoom, setLeafletReady, pins, editingPin, pinMode, railwayData,
-        setEditingPin, setPinMode, visitedStations
-    } = useStore(useShallow(state => ({
-        geoData: state.geoData,
-        leafletReady: state.leafletReady,
-        tripSegmentsGeometry: state.tripSegmentsGeometry,
-        activeTab: state.activeTab,
-        mapZoom: state.mapZoom,
-        setMapZoom: state.setMapZoom,
-        setLeafletReady: state.setLeafletReady,
-        pins: state.pins,
-        editingPin: state.editingPin,
-        pinMode: state.pinMode,
-        railwayData: state.railwayData,
-        setEditingPin: state.setEditingPin,
-        setPinMode: state.setPinMode,
-        visitedStations: state.visitedStations
-    })));
+    requestAnimationFrame(step);
+  };
 
-    useEffect(() => {
-        setLeafletReady(true);
-    }, [setLeafletReady]);
+  const {
+    geoData,
+    leafletReady,
+    tripSegmentsGeometry,
+    activeTab,
+    mapZoom,
+    setMapZoom,
+    setLeafletReady,
+    pins,
+    editingPin,
+    pinMode,
+    railwayData,
+    setEditingPin,
+    setPinMode,
+    visitedStations,
+  } = useStore(
+    useShallow((state) => ({
+      geoData: state.geoData,
+      leafletReady: state.leafletReady,
+      tripSegmentsGeometry: state.tripSegmentsGeometry,
+      activeTab: state.activeTab,
+      mapZoom: state.mapZoom,
+      setMapZoom: state.setMapZoom,
+      setLeafletReady: state.setLeafletReady,
+      pins: state.pins,
+      editingPin: state.editingPin,
+      pinMode: state.pinMode,
+      railwayData: state.railwayData,
+      setEditingPin: state.setEditingPin,
+      setPinMode: state.setPinMode,
+      visitedStations: state.visitedStations,
+    })),
+  );
 
-    useEffect(() => {
-        if (activeTab === 'map' && leafletReady) {
-            setTimeout(initMap, 100);
-            setTimeout(() => { mapInstance.current?.invalidateSize(); }, 200);
+  useEffect(() => {
+    setLeafletReady(true);
+  }, [setLeafletReady]);
+
+  useEffect(() => {
+    if (activeTab === "map" && leafletReady) {
+      setTimeout(initMap, 100);
+      setTimeout(() => {
+        mapInstance.current?.invalidateSize();
+      }, 200);
+    }
+  }, [activeTab, leafletReady]);
+
+  useEffect(() => {
+    geoDataRef.current = geoData;
+    if (isMapInitialized && leafletReady && geoData) {
+      renderBaseMap(geoData);
+    }
+  }, [geoData, leafletReady, isMapInitialized, railwayData]);
+
+  useEffect(() => {
+    visitedStationsRef.current = visitedStations;
+    if (isMapInitialized && leafletReady && geoData) {
+      renderStations();
+    }
+  }, [geoData, leafletReady, isMapInitialized, visitedStations]);
+
+  useEffect(() => {
+    if (isMapInitialized && leafletReady && tripSegmentsGeometry) {
+      renderTripRoutes();
+    }
+  }, [tripSegmentsGeometry, leafletReady, mapZoom, isMapInitialized]);
+
+  useEffect(() => {
+    if (isMapInitialized && leafletReady && !isDraggingRef.current)
+      renderPins();
+  }, [pins, editingPin, pinMode, leafletReady, isMapInitialized]);
+
+  useEffect(() => {
+    const handleCreateTempPin = () => {
+      if (!mapInstance.current) return;
+      const c = mapInstance.current.getCenter();
+      setEditingPin({
+        id: "temp",
+        lat: c.lat,
+        lng: c.lng,
+        type: "photo",
+        color: "#ef4444",
+        isTemp: true,
+      } as any);
+      mapInstance.current.panBy([0, 150]);
+    };
+
+    const handleFlyToLocation = (e: Event) => {
+      if (!mapInstance.current) return;
+      const customEvent = e as CustomEvent;
+      const { lat, lng, zoom } = customEvent.detail;
+
+      // Set a flag on the map instance to distinguish programmatic moves
+      (mapInstance.current as any)._isLocateFlying = true;
+
+      mapInstance.current.flyTo([lat, lng], zoom, {
+        animate: true,
+        duration: 1,
+      });
+
+      // Clear flag after animation
+      setTimeout(() => {
+        if (mapInstance.current) {
+          (mapInstance.current as any)._isLocateFlying = false;
         }
-    }, [activeTab, leafletReady]);
+      }, 1100);
+    };
 
-    useEffect(() => {
-        geoDataRef.current = geoData;
-        if (isMapInitialized && leafletReady && geoData) {
-            renderBaseMap(geoData);
+    window.addEventListener("map:create-temp-pin", handleCreateTempPin);
+    window.addEventListener("map:fly-to-location", handleFlyToLocation);
+    return () => {
+      window.removeEventListener("map:create-temp-pin", handleCreateTempPin);
+      window.removeEventListener("map:fly-to-location", handleFlyToLocation);
+    };
+  }, [setEditingPin]);
+
+  const initMap = () => {
+    if (!mapRef.current || mapInstance.current) return;
+
+    let startLat = 35.6812;
+    let startLng = 139.7671;
+
+    const mapCenterSettings =
+      useStore.getState().badgeSettings?.defaultMapCenter;
+
+    if (mapCenterSettings) {
+      if (mapCenterSettings.mode === "fixed") {
+        startLat = mapCenterSettings.lat;
+        startLng = mapCenterSettings.lng;
+      } else if (mapCenterSettings.mode === "latest") {
+        const _trips = useStore.getState().trips;
+        if (
+          _trips &&
+          _trips.length > 0 &&
+          _trips[0].segments &&
+          _trips[0].segments.length > 0
+        ) {
+          const lastSegment = _trips[0].segments[_trips[0].segments.length - 1];
+          const geo = useStore.getState().geoData;
+          if (geo && geo.features) {
+            const targetFeature = geo.features.find(
+              (f: any) =>
+                f.properties.name === lastSegment.destination &&
+                f.properties.line === lastSegment.line,
+            );
+            if (
+              targetFeature &&
+              targetFeature.geometry &&
+              targetFeature.geometry.coordinates
+            ) {
+              startLat = targetFeature.geometry.coordinates[1];
+              startLng = targetFeature.geometry.coordinates[0];
+            }
+          }
         }
-    }, [geoData, leafletReady, isMapInitialized, railwayData]);
+      }
+    }
 
-    useEffect(() => {
-        visitedStationsRef.current = visitedStations;
-        if (isMapInitialized && leafletReady && geoData) {
-            renderStations();
+    const map = L.map(mapRef.current, {
+      zoomControl: true,
+      preferCanvas: true,
+    }).setView([startLat, startLng], 10);
+    const light = cachedTileLayer(
+      "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png",
+      { attribution: "© CARTO", subdomains: ["a", "b", "c", "d"], maxZoom: 20 },
+    );
+    const dark = cachedTileLayer(
+      "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png",
+      { attribution: "© CARTO", subdomains: ["a", "b", "c", "d"], maxZoom: 20 },
+    );
+    const rail = cachedTileLayer(
+      "https://{s}.tiles.openrailwaymap.org/standard/{z}/{x}/{y}.png",
+      { maxZoom: 20, opacity: 0, attribution: "© OpenRailwayMap" },
+    );
+    railLayerRef.current = rail;
+
+    const handleTileError = (e: any) => {
+      if (!e || !e.tile || !e.tile.src) return;
+      try {
+        const url = new URL(e.tile.src);
+        const domain = url.hostname;
+        const now = Date.now();
+
+        if (
+          !lastTileErrorTime[domain] ||
+          now - lastTileErrorTime[domain] > 60000
+        ) {
+          lastTileErrorTime[domain] = now;
+          toast.error(`地图加载失败 (${domain})\n请检查网络或切换 VPN 节点`, {
+            id: `tile-error-${domain}`,
+            duration: 5000,
+          });
         }
-    }, [geoData, leafletReady, isMapInitialized, visitedStations]);
+      } catch (err) {
+        // 忽略 URL 解析错误
+      }
+    };
 
-    useEffect(() => {
-        if (isMapInitialized && leafletReady && tripSegmentsGeometry) {
-            renderTripRoutes();
+    light.on("tileerror", handleTileError);
+    dark.on("tileerror", handleTileError);
+    rail.on("tileerror", handleTileError);
+
+    dark.addTo(map);
+    rail.addTo(map);
+    L.control
+      .layers(
+        { "标准 (light)": light, "暗色 (Dark)": dark },
+        { "详细配线图 (OpenRailwayMap)": rail },
+        { position: "topright" },
+      )
+      .addTo(map);
+
+    map.createPane("baseLinesPane");
+    const baseLinesPane = map.getPane("baseLinesPane")!;
+    baseLinesPane.style.zIndex = "390";
+    baseLinesPane.style.pointerEvents = "none";
+
+    map.createPane("baseStationsPane");
+    const baseStationsPane = map.getPane("baseStationsPane")!;
+    baseStationsPane.style.zIndex = "400";
+    baseStationsPane.style.pointerEvents = "none";
+
+    map.createPane("routePane");
+    const routePane = map.getPane("routePane")!;
+    routePane.style.zIndex = "410";
+    routePane.style.pointerEvents = "none";
+
+    map.createPane("visitedStationsPane");
+    const visitedStationsPane = map.getPane("visitedStationsPane")!;
+    visitedStationsPane.style.zIndex = "420";
+    visitedStationsPane.style.pointerEvents = "none";
+
+    mapInstance.current = map;
+
+    baseLinesRendererRef.current = L.svg({ pane: "baseLinesPane" });
+    baseStationsRendererRef.current = L.svg({ pane: "baseStationsPane" });
+    routeRendererRef.current = L.svg({ pane: "routePane" });
+    visitedStationsRendererRef.current = L.svg({ pane: "visitedStationsPane" });
+
+    baseLinesLayer.current = L.layerGroup();
+    baseStationsLayer.current = L.layerGroup().addTo(map);
+    routeLayer.current = L.layerGroup().addTo(map);
+    pinsLayer.current = L.layerGroup().addTo(map);
+    rubberBandLayerRef.current = L.layerGroup().addTo(map);
+
+    const updateLayerVisibility = () => {
+      const z = map.getZoom();
+      if (railLayerRef.current)
+        railLayerRef.current.setOpacity(z >= 15 ? 0.7 : z >= 12 ? 0.4 : 0);
+      const showBaseLines = z >= 10 && z < 12;
+      if (baseLinesLayer.current) {
+        if (showBaseLines) {
+          if (!map.hasLayer(baseLinesLayer.current)) {
+            map.addLayer(baseLinesLayer.current);
+            baseLinesLayer.current.invoke("bringToBack");
+          }
+        } else {
+          if (map.hasLayer(baseLinesLayer.current))
+            map.removeLayer(baseLinesLayer.current);
         }
-    }, [tripSegmentsGeometry, leafletReady, mapZoom, isMapInitialized]);
+      }
 
-    useEffect(() => {
-        if (isMapInitialized && leafletReady && !isDraggingRef.current) renderPins();
-    }, [pins, editingPin, pinMode, leafletReady, isMapInitialized]);
+      const baseStationsPane = map.getPane("baseStationsPane");
+      if (baseStationsPane) {
+        baseStationsPane.style.display = z < 5 ? "none" : "";
+      }
+      const visitedStationsPane = map.getPane("visitedStationsPane");
+      if (visitedStationsPane) {
+        visitedStationsPane.style.display = z <= 7 ? "none" : "";
+      }
 
-    useEffect(() => {
-        const handleCreateTempPin = () => {
-            if (!mapInstance.current) return;
-            const c = mapInstance.current.getCenter();
-            setEditingPin({ id: 'temp', lat: c.lat, lng: c.lng, type: 'photo', color: '#ef4444', isTemp: true } as any);
-            mapInstance.current.panBy([0, 150]);
+      setMapZoom(z);
+    };
+
+    map.on("zoomend", updateLayerVisibility);
+    updateLayerVisibility();
+
+    // Listen to moveend to update stations with new bounds
+    map.on("moveend", () => {
+      renderStations();
+    });
+
+    // Listen for true user interactions to interrupt locate status
+    const handleUserInterruption = () => {
+      if (!(map as any)._isLocateFlying) {
+        window.dispatchEvent(new CustomEvent("map:user-interaction"));
+      }
+    };
+    map.on("dragstart", handleUserInterruption);
+    map.on("zoomstart", (e: any) => {
+      // Check if zoom was triggered by touch/scroll/controls rather than flyTo
+      if (!(map as any)._isLocateFlying) {
+        handleUserInterruption();
+      }
+    });
+
+    map.on("click", (e: L.LeafletMouseEvent) => {
+      if (wasDraggingRef.current) {
+        wasDraggingRef.current = false;
+        return;
+      }
+
+      const currentPinMode = useStore.getState().pinMode;
+      const currentEditingPin = useStore.getState().editingPin;
+
+      if (currentPinMode !== PinMode.Idle && currentEditingPin) {
+        let newPos = {
+          lat: e.latlng.lat,
+          lng: e.latlng.lng,
+          lineKey: currentEditingPin.lineKey,
+          percentage: currentEditingPin.percentage,
         };
-        window.addEventListener('map:create-temp-pin', handleCreateTempPin);
-        return () => window.removeEventListener('map:create-temp-pin', handleCreateTempPin);
-    }, [setEditingPin]);
-
-    const initMap = () => {
-        if (!mapRef.current || mapInstance.current) return;
-
-        let startLat = 35.6812;
-        let startLng = 139.7671;
-
-        const mapCenterSettings = useStore.getState().badgeSettings?.defaultMapCenter;
-
-        if (mapCenterSettings) {
-            if (mapCenterSettings.mode === 'fixed') {
-                startLat = mapCenterSettings.lat;
-                startLng = mapCenterSettings.lng;
-            } else if (mapCenterSettings.mode === 'latest') {
-                const _trips = useStore.getState().trips;
-                if (_trips && _trips.length > 0 && _trips[0].segments && _trips[0].segments.length > 0) {
-                    const lastSegment = _trips[0].segments[_trips[0].segments.length - 1];
-                    const geo = useStore.getState().geoData;
-                    if (geo && geo.features) {
-                        const targetFeature = geo.features.find((f: any) => f.properties.name === lastSegment.destination && f.properties.line === lastSegment.line);
-                        if (targetFeature && targetFeature.geometry && targetFeature.geometry.coordinates) {
-                            startLat = targetFeature.geometry.coordinates[1];
-                            startLng = targetFeature.geometry.coordinates[0];
-                        }
-                    }
-                }
-            }
+        if (currentPinMode === PinMode.Snap) {
+          const snap = findNearestPointOnLine(
+            useStore.getState().railwayData,
+            newPos.lat,
+            newPos.lng,
+          );
+          newPos = { ...newPos, ...snap };
         }
+        setEditingPin({ ...currentEditingPin, ...newPos });
+      } else {
+        setStationMenu(null);
+      }
+    });
 
-        const map = L.map(mapRef.current, { zoomControl: true, preferCanvas: true }).setView([startLat, startLng], 10);
-        const light = cachedTileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', { attribution: '© CARTO', subdomains: ['a', 'b', 'c', 'd'], maxZoom: 20 });
-        const dark = cachedTileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', { attribution: '© CARTO', subdomains: ['a', 'b', 'c', 'd'], maxZoom: 20 });
-        const rail = cachedTileLayer('https://{s}.tiles.openrailwaymap.org/standard/{z}/{x}/{y}.png', { maxZoom: 20, opacity: 0, attribution: '© OpenRailwayMap' });
-        railLayerRef.current = rail;
+    // Global mouse/touch move and up listeners for localized drag
+    const handleGlobalMove = (e: MouseEvent | TouchEvent) => {
+      if (
+        !routeDragRef.current.active ||
+        !routeDragRef.current.startStation ||
+        !rubberBandLayerRef.current
+      )
+        return;
 
-        const handleTileError = (e: any) => {
-            if (!e || !e.tile || !e.tile.src) return;
-            try {
-                const url = new URL(e.tile.src);
-                const domain = url.hostname;
-                const now = Date.now();
+      const startStation = routeDragRef.current.startStation;
+      const startLat = startStation.geometry.coordinates[1];
+      const startLng = startStation.geometry.coordinates[0];
 
-                if (!lastTileErrorTime[domain] || now - lastTileErrorTime[domain] > 60000) {
-                    lastTileErrorTime[domain] = now;
-                    toast.error(`地图加载失败 (${domain})\n请检查网络或切换 VPN 节点`, {
-                        id: `tile-error-${domain}`,
-                        duration: 5000,
-                    });
-                }
-            } catch (err) {
-                // 忽略 URL 解析错误
+      let clientX, clientY;
+      if ("touches" in e) {
+        clientX = (e as TouchEvent).touches[0].clientX;
+        clientY = (e as TouchEvent).touches[0].clientY;
+      } else {
+        clientX = (e as MouseEvent).clientX;
+        clientY = (e as MouseEvent).clientY;
+      }
+
+      const mapRect = map.getContainer().getBoundingClientRect();
+      const containerPoint = L.point(
+        clientX - mapRect.left,
+        clientY - mapRect.top,
+      );
+      const mouseLatLng = map.containerPointToLatLng(containerPoint);
+
+      // --- April Fool's Snap Trap ---
+      if (useStore.getState().isAprilFool) {
+        const startContainerPoint = map.latLngToContainerPoint([
+          startLat,
+          startLng,
+        ]);
+        const distToStart = containerPoint.distanceTo(startContainerPoint);
+        const viewportThreshold = Math.max(mapRect.width, mapRect.height) * 0.3;
+
+        if (distToStart > viewportThreshold) {
+          // Trigger the trap!
+          routeDragRef.current.active = false;
+
+          // Close tooltips
+          routeDragRef.current.openedTooltips.forEach((layer) => {
+            if ((layer as any).closeTooltip) {
+              const tooltip = (layer as any).getTooltip
+                ? (layer as any).getTooltip()
+                : null;
+              if (tooltip) {
+                const el = tooltip.getElement();
+                if (el) el.classList.remove("tooltip-highlight");
+              }
+              (layer as any).closeTooltip();
             }
-        };
+          });
+          routeDragRef.current.openedTooltips.clear();
 
-        light.on('tileerror', handleTileError);
-        dark.on('tileerror', handleTileError);
-        rail.on('tileerror', handleTileError);
-
-        dark.addTo(map); rail.addTo(map);
-        L.control.layers({ "标准 (light)": light, "暗色 (Dark)": dark }, { "详细配线图 (OpenRailwayMap)": rail }, { position: 'topright' }).addTo(map);
-
-        map.createPane('baseLinesPane');
-        const baseLinesPane = map.getPane('baseLinesPane')!;
-        baseLinesPane.style.zIndex = '390';
-        baseLinesPane.style.pointerEvents = 'none';
-
-        map.createPane('baseStationsPane');
-        const baseStationsPane = map.getPane('baseStationsPane')!;
-        baseStationsPane.style.zIndex = '400';
-        baseStationsPane.style.pointerEvents = 'none';
-
-        map.createPane('routePane');
-        const routePane = map.getPane('routePane')!;
-        routePane.style.zIndex = '410';
-        routePane.style.pointerEvents = 'none';
-
-        map.createPane('visitedStationsPane');
-        const visitedStationsPane = map.getPane('visitedStationsPane')!;
-        visitedStationsPane.style.zIndex = '420';
-        visitedStationsPane.style.pointerEvents = 'none';
-
-        mapInstance.current = map;
-
-        baseLinesRendererRef.current = L.svg({ pane: 'baseLinesPane' });
-        baseStationsRendererRef.current = L.svg({ pane: 'baseStationsPane' });
-        routeRendererRef.current = L.svg({ pane: 'routePane' });
-        visitedStationsRendererRef.current = L.svg({ pane: 'visitedStationsPane' });
-
-        baseLinesLayer.current = L.layerGroup();
-        baseStationsLayer.current = L.layerGroup().addTo(map);
-        routeLayer.current = L.layerGroup().addTo(map);
-        pinsLayer.current = L.layerGroup().addTo(map);
-        rubberBandLayerRef.current = L.layerGroup().addTo(map);
-
-        const updateLayerVisibility = () => {
-            const z = map.getZoom();
-            if (railLayerRef.current) railLayerRef.current.setOpacity(z >= 15 ? 0.7 : (z >= 12 ? 0.4 : 0));
-            const showBaseLines = z >= 10 && z < 12;
-            if (baseLinesLayer.current) {
-                if (showBaseLines) {
-                    if (!map.hasLayer(baseLinesLayer.current)) {
-                        map.addLayer(baseLinesLayer.current);
-                        baseLinesLayer.current.invoke('bringToBack');
-                    }
-                } else {
-                    if (map.hasLayer(baseLinesLayer.current)) map.removeLayer(baseLinesLayer.current);
-                }
-            }
-
-            const baseStationsPane = map.getPane('baseStationsPane');
-            if (baseStationsPane) {
-                baseStationsPane.style.display = z < 5 ? 'none' : '';
-            }
-            const visitedStationsPane = map.getPane('visitedStationsPane');
-            if (visitedStationsPane) {
-                visitedStationsPane.style.display = z <= 7 ? 'none' : '';
-            }
-
-            setMapZoom(z);
-        };
-
-        map.on('zoomend', updateLayerVisibility);
-        updateLayerVisibility();
-
-        // Listen to moveend to update stations with new bounds
-        map.on('moveend', () => {
-            renderStations();
-        });
-
-        map.on('click', (e: L.LeafletMouseEvent) => {
-            if (wasDraggingRef.current) {
-                wasDraggingRef.current = false;
-                return;
-            }
-
-            const currentPinMode = useStore.getState().pinMode;
-            const currentEditingPin = useStore.getState().editingPin;
-
-            if (currentPinMode !== PinMode.Idle && currentEditingPin) {
-                let newPos = { lat: e.latlng.lat, lng: e.latlng.lng, lineKey: currentEditingPin.lineKey, percentage: currentEditingPin.percentage };
-                if (currentPinMode === PinMode.Snap) {
-                    const snap = findNearestPointOnLine(useStore.getState().railwayData, newPos.lat, newPos.lng);
-                    newPos = { ...newPos, ...snap };
-                }
-                setEditingPin({ ...currentEditingPin, ...newPos });
-            } else {
-                setStationMenu(null);
-            }
-        });
-
-        // Global mouse/touch move and up listeners for localized drag
-        const handleGlobalMove = (e: MouseEvent | TouchEvent) => {
-            if (!routeDragRef.current.active || !routeDragRef.current.startStation || !rubberBandLayerRef.current) return;
-
-            const startStation = routeDragRef.current.startStation;
-            const startLat = startStation.geometry.coordinates[1];
-            const startLng = startStation.geometry.coordinates[0];
-
-            let clientX, clientY;
-            if ('touches' in e) {
-                clientX = (e as TouchEvent).touches[0].clientX;
-                clientY = (e as TouchEvent).touches[0].clientY;
-            } else {
-                clientX = (e as MouseEvent).clientX;
-                clientY = (e as MouseEvent).clientY;
-            }
-
-            const mapRect = map.getContainer().getBoundingClientRect();
-            const containerPoint = L.point(clientX - mapRect.left, clientY - mapRect.top);
-            const mouseLatLng = map.containerPointToLatLng(containerPoint);
-
-            // --- April Fool's Snap Trap ---
-            if (useStore.getState().isAprilFool) {
-                const startContainerPoint = map.latLngToContainerPoint([startLat, startLng]);
-                const distToStart = containerPoint.distanceTo(startContainerPoint);
-                const viewportThreshold = Math.max(mapRect.width, mapRect.height) * 0.3;
-
-                if (distToStart > viewportThreshold) {
-                    // Trigger the trap!
-                    routeDragRef.current.active = false;
-
-                    // Close tooltips
-                    routeDragRef.current.openedTooltips.forEach(layer => {
-                        if ((layer as any).closeTooltip) {
-                            const tooltip = (layer as any).getTooltip ? (layer as any).getTooltip() : null;
-                            if (tooltip) {
-                                const el = tooltip.getElement();
-                                if (el) el.classList.remove('tooltip-highlight');
-                            }
-                            (layer as any).closeTooltip();
-                        }
-                    });
-                    routeDragRef.current.openedTooltips.clear();
-
-                    let trapStyle: HTMLStyleElement | null = null;
-                    const rubberLine = routeDragRef.current.rubberLine;
-                    if (rubberLine) {
-                        const lineElement = rubberLine.getElement();
-                        if (lineElement) {
-                            // Inject random snap animation
-                            const animName = `snap-fail-rand-${Math.floor(Math.random() * 10000)}`;
-                            trapStyle = document.createElement('style');
-                            const rx = (Math.random() - 0.5) * 50;
-                            const ry = (Math.random() - 0.5) * 50;
-                            trapStyle.innerHTML = `
+          let trapStyle: HTMLStyleElement | null = null;
+          const rubberLine = routeDragRef.current.rubberLine;
+          if (rubberLine) {
+            const lineElement = rubberLine.getElement();
+            if (lineElement) {
+              // Inject random snap animation
+              const animName = `snap-fail-rand-${Math.floor(Math.random() * 10000)}`;
+              trapStyle = document.createElement("style");
+              const rx = (Math.random() - 0.5) * 50;
+              const ry = (Math.random() - 0.5) * 50;
+              trapStyle.innerHTML = `
                                 @keyframes ${animName} {
                                     0% { stroke-width: 6; opacity: 1; transform: translate(0px, 0px) scale(1); }
                                     25% { stroke-width: 15; transform: translate(${rx}px, ${ry}px) scale(1.5) skew(${rx}deg); }
@@ -348,685 +502,889 @@ export const MapContainer: React.FC<Props> = ({ setStationMenu, isDraggingRef })
                                     transform-origin: center;
                                 }
                             `;
-                            document.head.appendChild(trapStyle);
-                            lineElement.classList.remove('rubber-band-line');
-                            lineElement.classList.add(`${animName}-class`);
-                        }
-
-                        const linePoints = rubberLine.getLatLngs() as L.LatLng[];
-                        if (linePoints.length >= 2) {
-                            animateRubberRetract(rubberLine, L.latLng(startLat, startLng), linePoints[linePoints.length - 1]);
-                        }
-                    }
-
-                    if (mapRef.current) {
-                        mapRef.current.classList.add('map-shake');
-                    }
-
-                    toast.error('哎呀！橡皮筋拉断了，弹到手了！💥', { duration: 2500, position: 'top-center' });
-
-                    setTimeout(() => {
-                        if (mapRef.current) {
-                            mapRef.current.classList.remove('map-shake');
-                        }
-                        if (rubberBandLayerRef.current) rubberBandLayerRef.current.clearLayers();
-                        routeDragRef.current = { active: false, startStation: null, currentSnap: null, rubberLine: null, snapCircleCenter: null, openedTooltips: new Set() };
-                        map.dragging.enable();
-                        // Clean up the dynamically created style tag
-                        if (trapStyle?.parentNode) {
-                            trapStyle.parentNode.removeChild(trapStyle);
-                        }
-                    }, 500);
-
-                    return;
-                }
+              document.head.appendChild(trapStyle);
+              lineElement.classList.remove("rubber-band-line");
+              lineElement.classList.add(`${animName}-class`);
             }
 
-            let nearestDist = Infinity;
-            let nearestStation: any = null;
-            let nearestLatLng: L.LatLng | null = null;
-
-            const newOpenedTooltips = new Set<L.Layer>();
-
-            if (geoDataRef.current && baseStationsLayer.current) {
-                const candidates: { layer: any, dist: number }[] = [];
-
-                // To display tooltips within 100px, we should iterate over rendered layers in baseStationsLayer
-                // because we need access to the layer object to call `openTooltip()`.
-                baseStationsLayer.current.eachLayer((layer: any) => {
-                    if (typeof layer.getLatLng === 'function') {
-                        const latlng = layer.getLatLng();
-                        const stPoint = map.latLngToContainerPoint([latlng.lat, latlng.lng]);
-                        const dist = containerPoint.distanceTo(stPoint);
-
-                        // Tooltip logic (100px)
-                        if (dist <= 100) {
-                            candidates.push({ layer, dist });
-                        }
-                    }
-                });
-
-                // Sort by distance and limit to the closest 5
-                candidates.sort((a, b) => a.dist - b.dist);
-                const closestCandidates = candidates.slice(0, 5);
-
-                closestCandidates.forEach(({ layer }, index) => {
-                    const tooltip = layer.getTooltip ? layer.getTooltip() : null;
-                    if (tooltip) {
-                        if (!layer.isTooltipOpen()) {
-                            layer.openTooltip();
-                        }
-
-                        const el = tooltip.getElement();
-                        if (el) {
-                            if (index === 0) {
-                                el.classList.add('tooltip-highlight');
-                            } else {
-                                el.classList.remove('tooltip-highlight');
-                            }
-                        }
-                        newOpenedTooltips.add(layer);
-                    }
-                });
-
-                // Original GeoData search to find nearest feature for snap logic
-                geoDataRef.current.features.forEach((f: any) => {
-                    if (f.properties.type === 'station' && f.geometry?.coordinates) {
-                        const lat = f.geometry.coordinates[1];
-                        const lng = f.geometry.coordinates[0];
-                        // Skip the start station itself
-                        if (f.properties.name === startStation.properties.name && f.properties.line === startStation.properties.line) return;
-
-                        const stPoint = map.latLngToContainerPoint([lat, lng]);
-                        const dist = containerPoint.distanceTo(stPoint);
-
-                        if (dist < 40 && dist < nearestDist) {
-                            nearestDist = dist;
-                            nearestStation = f;
-                            nearestLatLng = L.latLng(lat, lng);
-                        }
-                    }
-                });
+            const linePoints = rubberLine.getLatLngs() as L.LatLng[];
+            if (linePoints.length >= 2) {
+              animateRubberRetract(
+                rubberLine,
+                L.latLng(startLat, startLng),
+                linePoints[linePoints.length - 1],
+              );
             }
+          }
 
-            // Close tooltips that are no longer within 100px
-            routeDragRef.current.openedTooltips.forEach(layer => {
-                if (!newOpenedTooltips.has(layer) && (layer as any).closeTooltip) {
-                    const tooltip = (layer as any).getTooltip ? (layer as any).getTooltip() : null;
-                    if (tooltip) {
-                        const el = tooltip.getElement();
-                        if (el) {
-                            el.classList.remove('tooltip-highlight');
-                        }
-                    }
-                    (layer as any).closeTooltip();
-                }
-            });
-            routeDragRef.current.openedTooltips = newOpenedTooltips;
+          if (mapRef.current) {
+            mapRef.current.classList.add("map-shake");
+          }
 
-            routeDragRef.current.currentSnap = nearestStation;
+          toast.error("哎呀！橡皮筋拉断了，弹到手了！💥", {
+            duration: 2500,
+            position: "top-center",
+          });
 
-            const rubberLine = routeDragRef.current.rubberLine;
-            const snapCircleCenter = routeDragRef.current.snapCircleCenter;
-
-            if (rubberLine && snapCircleCenter) {
-                if (nearestStation && nearestLatLng) {
-                    rubberLine.setLatLngs([[startLat, startLng], nearestLatLng]);
-                    snapCircleCenter.setLatLng(nearestLatLng).setStyle({ opacity: 1, fillOpacity: 1 });
-
-                    // Clear fail class, add success class immediately if needed, but usually we just pulse
-                    const lineElement = rubberLine.getElement();
-                    if (lineElement) {
-                        lineElement.classList.add('rubber-band-success');
-                    }
-
-                } else {
-                    rubberLine.setLatLngs([[startLat, startLng], mouseLatLng]);
-                    snapCircleCenter.setStyle({ opacity: 0, fillOpacity: 0 });
-                    const lineElement = rubberLine.getElement();
-                    if (lineElement) {
-                        lineElement.classList.remove('rubber-band-success');
-                    }
-                }
+          setTimeout(() => {
+            if (mapRef.current) {
+              mapRef.current.classList.remove("map-shake");
             }
-        };
-
-        const handleGlobalUp = (e: MouseEvent | TouchEvent) => {
-            if (pressTimerRef.current) {
-                clearTimeout(pressTimerRef.current);
-                pressTimerRef.current = null;
-
-                // If the drag wasn't active, we still disabled map dragging on mousedown, so re-enable it.
-                if (!routeDragRef.current.active) {
-                    map.dragging.enable();
-                }
-            }
-
-            if (!routeDragRef.current.active) return;
-
-            // Immediately close dynamically opened tooltips
-            routeDragRef.current.openedTooltips.forEach(layer => {
-                if ((layer as any).closeTooltip) {
-                    const tooltip = (layer as any).getTooltip ? (layer as any).getTooltip() : null;
-                    if (tooltip) {
-                        const el = tooltip.getElement();
-                        if (el) {
-                            el.classList.remove('tooltip-highlight');
-                        }
-                    }
-                    (layer as any).closeTooltip();
-                }
-            });
-            routeDragRef.current.openedTooltips.clear();
-
-            routeDragRef.current.active = false;
+            if (rubberBandLayerRef.current)
+              rubberBandLayerRef.current.clearLayers();
+            routeDragRef.current = {
+              active: false,
+              startStation: null,
+              currentSnap: null,
+              rubberLine: null,
+              snapCircleCenter: null,
+              openedTooltips: new Set(),
+            };
             map.dragging.enable();
-            wasDraggingRef.current = true; // prevent click
-
-            const currentSnap = routeDragRef.current.currentSnap;
-            const startStation = routeDragRef.current.startStation;
-            const rubberLine = routeDragRef.current.rubberLine;
-
-            if (currentSnap && startStation) {
-                // Success: Snap, animate, then trigger auto-plan and fade out
-                if (rubberLine) {
-                    const lineElement = rubberLine.getElement();
-                    if (lineElement) {
-                        lineElement.classList.add('rubber-band-success');
-                        lineElement.classList.remove('rubber-band-line'); // stop dash flow
-                    }
-                }
-
-                setTimeout(() => {
-                    const snapProps = currentSnap.properties;
-                    const snapLineKey = `${snapProps.company}:${snapProps.line}`;
-                    const startLineKey = `${startStation.properties.company}:${startStation.properties.line}`;
-
-                    const startStationId = startStation.properties.id || `${startStation.properties.company}:${startStation.properties.line}:${startStation.properties.name}`;
-                    const endStationId = snapProps.id || `${snapProps.company}:${snapProps.line}:${snapProps.name}`;
-
-                    const { setEditorMode, setAutoForm, startEditingTrip, isAprilFool, setAutoRouteEasterEggType, setIsRouteSearching } = useStore.getState();
-
-                    // --- April Fool's Map Auto-Plan Hijack ---
-                    setEditorMode('auto');
-                    setAutoForm({
-                        startLine: startLineKey,
-                        startStation: startStationId,
-                        endLine: snapLineKey,
-                        endStation: endStationId
-                    });
-
-                    const rand = Math.random();
-                    if (isAprilFool && rand < 1 / 3) {
-                        const type = rand < 1 / 6 ? 'ufo' : 'tree';
-                        // Open the TripEditor normally, but force it into an immediate Easter Egg searching state
-                        setAutoRouteEasterEggType(type);
-                        setIsRouteSearching(true);
-                        startEditingTrip();
-                    } else {
-                        startEditingTrip();
-                    }
-
-                    if (rubberBandLayerRef.current) rubberBandLayerRef.current.clearLayers();
-                    routeDragRef.current = { active: false, startStation: null, currentSnap: null, rubberLine: null, snapCircleCenter: null, openedTooltips: new Set() };
-                }, 300); // Wait for success animation
-
-            } else {
-                // Fail: Animate fail and disappear
-                if (rubberLine) {
-                    const lineElement = rubberLine.getElement();
-                    if (lineElement) {
-                        lineElement.classList.remove('rubber-band-line');
-                        lineElement.classList.add('rubber-band-fail');
-                    }
-                    const linePoints = rubberLine.getLatLngs() as L.LatLng[];
-                    if (linePoints.length >= 2) {
-                        animateRubberRetract(rubberLine, linePoints[0], linePoints[linePoints.length - 1]);
-                    }
-                }
-
-                setTimeout(() => {
-                    if (rubberBandLayerRef.current) rubberBandLayerRef.current.clearLayers();
-                    routeDragRef.current = { active: false, startStation: null, currentSnap: null, rubberLine: null, snapCircleCenter: null, openedTooltips: new Set() };
-                }, 300);
+            // Clean up the dynamically created style tag
+            if (trapStyle?.parentNode) {
+              trapStyle.parentNode.removeChild(trapStyle);
             }
-        };
+          }, 500);
 
-        window.addEventListener('mousemove', handleGlobalMove);
-        window.addEventListener('touchmove', handleGlobalMove, { passive: false });
-        window.addEventListener('mouseup', handleGlobalUp);
-        window.addEventListener('touchend', handleGlobalUp);
+          return;
+        }
+      }
 
-        // Store cleanup on map instance for unmounting
-        (map as any)._customDragCleanup = () => {
-            window.removeEventListener('mousemove', handleGlobalMove);
-            window.removeEventListener('touchmove', handleGlobalMove);
-            window.removeEventListener('mouseup', handleGlobalUp);
-            window.removeEventListener('touchend', handleGlobalUp);
-        };
+      let nearestDist = Infinity;
+      let nearestStation: any = null;
+      let nearestLatLng: L.LatLng | null = null;
 
-        setIsMapInitialized(true);
+      const newOpenedTooltips = new Set<L.Layer>();
+
+      if (geoDataRef.current && baseStationsLayer.current) {
+        const candidates: { layer: any; dist: number }[] = [];
+
+        // To display tooltips within 100px, we should iterate over rendered layers in baseStationsLayer
+        // because we need access to the layer object to call `openTooltip()`.
+        baseStationsLayer.current.eachLayer((layer: any) => {
+          if (typeof layer.getLatLng === "function") {
+            const latlng = layer.getLatLng();
+            const stPoint = map.latLngToContainerPoint([
+              latlng.lat,
+              latlng.lng,
+            ]);
+            const dist = containerPoint.distanceTo(stPoint);
+
+            // Tooltip logic (100px)
+            if (dist <= 100) {
+              candidates.push({ layer, dist });
+            }
+          }
+        });
+
+        // Sort by distance and limit to the closest 5
+        candidates.sort((a, b) => a.dist - b.dist);
+        const closestCandidates = candidates.slice(0, 5);
+
+        closestCandidates.forEach(({ layer }, index) => {
+          const tooltip = layer.getTooltip ? layer.getTooltip() : null;
+          if (tooltip) {
+            if (!layer.isTooltipOpen()) {
+              layer.openTooltip();
+            }
+
+            const el = tooltip.getElement();
+            if (el) {
+              if (index === 0) {
+                el.classList.add("tooltip-highlight");
+              } else {
+                el.classList.remove("tooltip-highlight");
+              }
+            }
+            newOpenedTooltips.add(layer);
+          }
+        });
+
+        // Original GeoData search to find nearest feature for snap logic
+        geoDataRef.current.features.forEach((f: any) => {
+          if (f.properties.type === "station" && f.geometry?.coordinates) {
+            const lat = f.geometry.coordinates[1];
+            const lng = f.geometry.coordinates[0];
+            // Skip the start station itself
+            if (
+              f.properties.name === startStation.properties.name &&
+              f.properties.line === startStation.properties.line
+            )
+              return;
+
+            const stPoint = map.latLngToContainerPoint([lat, lng]);
+            const dist = containerPoint.distanceTo(stPoint);
+
+            if (dist < 40 && dist < nearestDist) {
+              nearestDist = dist;
+              nearestStation = f;
+              nearestLatLng = L.latLng(lat, lng);
+            }
+          }
+        });
+      }
+
+      // Close tooltips that are no longer within 100px
+      routeDragRef.current.openedTooltips.forEach((layer) => {
+        if (!newOpenedTooltips.has(layer) && (layer as any).closeTooltip) {
+          const tooltip = (layer as any).getTooltip
+            ? (layer as any).getTooltip()
+            : null;
+          if (tooltip) {
+            const el = tooltip.getElement();
+            if (el) {
+              el.classList.remove("tooltip-highlight");
+            }
+          }
+          (layer as any).closeTooltip();
+        }
+      });
+      routeDragRef.current.openedTooltips = newOpenedTooltips;
+
+      routeDragRef.current.currentSnap = nearestStation;
+
+      const rubberLine = routeDragRef.current.rubberLine;
+      const snapCircleCenter = routeDragRef.current.snapCircleCenter;
+
+      if (rubberLine && snapCircleCenter) {
+        if (nearestStation && nearestLatLng) {
+          rubberLine.setLatLngs([[startLat, startLng], nearestLatLng]);
+          snapCircleCenter
+            .setLatLng(nearestLatLng)
+            .setStyle({ opacity: 1, fillOpacity: 1 });
+
+          // Clear fail class, add success class immediately if needed, but usually we just pulse
+          const lineElement = rubberLine.getElement();
+          if (lineElement) {
+            lineElement.classList.add("rubber-band-success");
+          }
+        } else {
+          rubberLine.setLatLngs([[startLat, startLng], mouseLatLng]);
+          snapCircleCenter.setStyle({ opacity: 0, fillOpacity: 0 });
+          const lineElement = rubberLine.getElement();
+          if (lineElement) {
+            lineElement.classList.remove("rubber-band-success");
+          }
+        }
+      }
     };
 
-    useEffect(() => {
-        return () => {
-            if (mapInstance.current && (mapInstance.current as any)._customDragCleanup) {
-                (mapInstance.current as any)._customDragCleanup();
+    const handleGlobalUp = (e: MouseEvent | TouchEvent) => {
+      if (pressTimerRef.current) {
+        clearTimeout(pressTimerRef.current);
+        pressTimerRef.current = null;
+
+        // If the drag wasn't active, we still disabled map dragging on mousedown, so re-enable it.
+        if (!routeDragRef.current.active) {
+          map.dragging.enable();
+        }
+      }
+
+      if (!routeDragRef.current.active) return;
+
+      // Immediately close dynamically opened tooltips
+      routeDragRef.current.openedTooltips.forEach((layer) => {
+        if ((layer as any).closeTooltip) {
+          const tooltip = (layer as any).getTooltip
+            ? (layer as any).getTooltip()
+            : null;
+          if (tooltip) {
+            const el = tooltip.getElement();
+            if (el) {
+              el.classList.remove("tooltip-highlight");
             }
-        };
-    }, []);
+          }
+          (layer as any).closeTooltip();
+        }
+      });
+      routeDragRef.current.openedTooltips.clear();
 
+      routeDragRef.current.active = false;
+      map.dragging.enable();
+      wasDraggingRef.current = true; // prevent click
 
-    const renderStations = () => {
-        if (!baseStationsLayer.current || !mapInstance.current || !geoDataRef.current) return;
+      const currentSnap = routeDragRef.current.currentSnap;
+      const startStation = routeDragRef.current.startStation;
+      const rubberLine = routeDragRef.current.rubberLine;
 
-        const map = mapInstance.current;
-        const currentZoom = map.getZoom();
-
-        // At zoom < 5, strictly provide empty array to clear/hide stations
-        if (currentZoom < 5) {
-            syncLeafletLayerGroup<CustomGeoJSONFeature>(
-                baseStationsLayer.current,
-                [],
-                (f) => f.properties.id || `${f.properties.company}:${f.properties.line}:${f.properties.name}`,
-                (f) => L.circleMarker([0, 0]),
-                () => { }
-            );
-            return;
+      if (currentSnap && startStation) {
+        // Success: Snap, animate, then trigger auto-plan and fade out
+        if (rubberLine) {
+          const lineElement = rubberLine.getElement();
+          if (lineElement) {
+            lineElement.classList.add("rubber-band-success");
+            lineElement.classList.remove("rubber-band-line"); // stop dash flow
+          }
         }
 
-        // Calculate dynamic zoom scale
-        let scale = Math.pow(2, currentZoom - 12);
-        scale = Math.min(scale, 1.5);
+        setTimeout(() => {
+          const snapProps = currentSnap.properties;
+          const snapLineKey = `${snapProps.company}:${snapProps.line}`;
+          const startLineKey = `${startStation.properties.company}:${startStation.properties.line}`;
 
-        const baseUnvisitedRadius = 4 * scale;
-        const baseVisitedRadius = 5 * Math.max(0.2, scale);
-        const baseVisitedWeight = 2 * Math.max(0.3, scale);
+          const startStationId =
+            startStation.properties.id ||
+            `${startStation.properties.company}:${startStation.properties.line}:${startStation.properties.name}`;
+          const endStationId =
+            snapProps.id ||
+            `${snapProps.company}:${snapProps.line}:${snapProps.name}`;
 
-        // Calculate 3x3 viewport bounds
-        const bounds = map.getBounds();
-        const latDiff = bounds.getNorth() - bounds.getSouth();
-        const lngDiff = bounds.getEast() - bounds.getWest();
+          const {
+            setEditorMode,
+            setAutoForm,
+            startEditingTrip,
+            isAprilFool,
+            setAutoRouteEasterEggType,
+            setIsRouteSearching,
+          } = useStore.getState();
 
-        const expandedBounds = L.latLngBounds(
-            L.latLng(bounds.getSouth() - latDiff, bounds.getWest() - lngDiff),
-            L.latLng(bounds.getNorth() + latDiff, bounds.getEast() + lngDiff)
-        );
+          // --- April Fool's Map Auto-Plan Hijack ---
+          setEditorMode("auto");
+          setAutoForm({
+            startLine: startLineKey,
+            startStation: startStationId,
+            endLine: snapLineKey,
+            endStation: endStationId,
+          });
 
-        // Filter stations within the expanded bounds
-        const stationFeatures = geoDataRef.current.features.filter((f: CustomGeoJSONFeature) => {
-            if (f.properties.type !== 'station') return false;
-            const lng = f.geometry.coordinates[0];
-            const lat = f.geometry.coordinates[1];
-            // Since it's point data, check if it's within the expanded bounds
-            return expandedBounds.contains([lat, lng]);
+          const rand = Math.random();
+          if (isAprilFool && rand < 1 / 3) {
+            const type = rand < 1 / 6 ? "ufo" : "tree";
+            // Open the TripEditor normally, but force it into an immediate Easter Egg searching state
+            setAutoRouteEasterEggType(type);
+            setIsRouteSearching(true);
+            startEditingTrip();
+          } else {
+            startEditingTrip();
+          }
+
+          if (rubberBandLayerRef.current)
+            rubberBandLayerRef.current.clearLayers();
+          routeDragRef.current = {
+            active: false,
+            startStation: null,
+            currentSnap: null,
+            rubberLine: null,
+            snapCircleCenter: null,
+            openedTooltips: new Set(),
+          };
+        }, 300); // Wait for success animation
+      } else {
+        // Fail: Animate fail and disappear
+        if (rubberLine) {
+          const lineElement = rubberLine.getElement();
+          if (lineElement) {
+            lineElement.classList.remove("rubber-band-line");
+            lineElement.classList.add("rubber-band-fail");
+          }
+          const linePoints = rubberLine.getLatLngs() as L.LatLng[];
+          if (linePoints.length >= 2) {
+            animateRubberRetract(
+              rubberLine,
+              linePoints[0],
+              linePoints[linePoints.length - 1],
+            );
+          }
+        }
+
+        setTimeout(() => {
+          if (rubberBandLayerRef.current)
+            rubberBandLayerRef.current.clearLayers();
+          routeDragRef.current = {
+            active: false,
+            startStation: null,
+            currentSnap: null,
+            rubberLine: null,
+            snapCircleCenter: null,
+            openedTooltips: new Set(),
+          };
+        }, 300);
+      }
+    };
+
+    window.addEventListener("mousemove", handleGlobalMove);
+    window.addEventListener("touchmove", handleGlobalMove, { passive: false });
+    window.addEventListener("mouseup", handleGlobalUp);
+    window.addEventListener("touchend", handleGlobalUp);
+
+    // Store cleanup on map instance for unmounting
+    (map as any)._customDragCleanup = () => {
+      window.removeEventListener("mousemove", handleGlobalMove);
+      window.removeEventListener("touchmove", handleGlobalMove);
+      window.removeEventListener("mouseup", handleGlobalUp);
+      window.removeEventListener("touchend", handleGlobalUp);
+    };
+
+    setIsMapInitialized(true);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (
+        mapInstance.current &&
+        (mapInstance.current as any)._customDragCleanup
+      ) {
+        (mapInstance.current as any)._customDragCleanup();
+      }
+    };
+  }, []);
+
+  const renderStations = () => {
+    if (
+      !baseStationsLayer.current ||
+      !mapInstance.current ||
+      !geoDataRef.current
+    )
+      return;
+
+    const map = mapInstance.current;
+    const currentZoom = map.getZoom();
+
+    // At zoom < 5, strictly provide empty array to clear/hide stations
+    if (currentZoom < 5) {
+      syncLeafletLayerGroup<CustomGeoJSONFeature>(
+        baseStationsLayer.current,
+        [],
+        (f) =>
+          f.properties.id ||
+          `${f.properties.company}:${f.properties.line}:${f.properties.name}`,
+        (f) => L.circleMarker([0, 0]),
+        () => {},
+      );
+      return;
+    }
+
+    // Calculate dynamic zoom scale
+    let scale = Math.pow(2, currentZoom - 12);
+    scale = Math.min(scale, 1.5);
+
+    const baseUnvisitedRadius = 4 * scale;
+    const baseVisitedRadius = 5 * Math.max(0.2, scale);
+    const baseVisitedWeight = 2 * Math.max(0.3, scale);
+
+    // Calculate 3x3 viewport bounds
+    const bounds = map.getBounds();
+    const latDiff = bounds.getNorth() - bounds.getSouth();
+    const lngDiff = bounds.getEast() - bounds.getWest();
+
+    const expandedBounds = L.latLngBounds(
+      L.latLng(bounds.getSouth() - latDiff, bounds.getWest() - lngDiff),
+      L.latLng(bounds.getNorth() + latDiff, bounds.getEast() + lngDiff),
+    );
+
+    // Filter stations within the expanded bounds
+    const stationFeatures = geoDataRef.current.features.filter(
+      (f: CustomGeoJSONFeature) => {
+        if (f.properties.type !== "station") return false;
+        const lng = f.geometry.coordinates[0];
+        const lat = f.geometry.coordinates[1];
+        // Since it's point data, check if it's within the expanded bounds
+        return expandedBounds.contains([lat, lng]);
+      },
+    );
+
+    syncLeafletLayerGroup<CustomGeoJSONFeature>(
+      baseStationsLayer.current,
+      stationFeatures,
+      (f) => {
+        const stationId =
+          f.properties.id ||
+          `${f.properties.company}:${f.properties.line}:${f.properties.name}`;
+        const isVisited = visitedStationsRef.current.has(stationId);
+        // Changing panes requires a different renderer. To avoid issues with Leaflet transferring SVG nodes,
+        // we treat a station moving between visited/base as a different entity id.
+        return `${stationId}_${isVisited ? "v" : "b"}`;
+      },
+      (f) => {
+        const latlng = [
+          f.geometry.coordinates[1],
+          f.geometry.coordinates[0],
+        ] as [number, number];
+        const stationId =
+          f.properties.id ||
+          `${f.properties.company}:${f.properties.line}:${f.properties.name}`;
+        const isVisited = visitedStationsRef.current.has(stationId);
+        const lineColor = f.properties.stroke || "#64748b"; // Fallback if no stroke defined
+
+        const targetRadius = isVisited
+          ? baseVisitedRadius
+          : baseUnvisitedRadius;
+        const targetWeight = isVisited ? baseVisitedWeight : 0;
+
+        const currentRenderer = isVisited
+          ? visitedStationsRendererRef.current!
+          : baseStationsRendererRef.current!;
+
+        const layer = L.circleMarker(latlng, {
+          renderer: currentRenderer,
+          radius: targetRadius,
+          color: isVisited ? "#ffffff" : "transparent",
+          fillColor: isVisited ? lineColor : "#64748b",
+          fillOpacity: isVisited ? 1.0 : 0.5,
+          weight: targetWeight,
+          className: "station-dot",
+          pane: isVisited ? "visitedStationsPane" : "baseStationsPane",
+        });
+        // @ts-ignore
+        layer._cachedIsVisited = isVisited;
+        if (f.properties.name) layer.bindTooltip(f.properties.name);
+
+        // @ts-ignore
+        layer._cachedLat = latlng[0];
+        // @ts-ignore
+        layer._cachedLng = latlng[1];
+        // @ts-ignore
+        layer._cachedName = f.properties.name;
+        // @ts-ignore
+        layer._cachedRadius = targetRadius;
+        // @ts-ignore
+        layer._cachedWeight = targetWeight;
+
+        let startX = 0;
+        let startY = 0;
+
+        const handlePointerDown = (e: L.LeafletEvent | L.LeafletMouseEvent) => {
+          L.DomEvent.stopPropagation(e);
+
+          if (pressTimerRef.current) clearTimeout(pressTimerRef.current);
+
+          const me = e as L.LeafletMouseEvent;
+          const originalEvent = me.originalEvent as MouseEvent | TouchEvent;
+          startX =
+            "clientX" in originalEvent
+              ? originalEvent.clientX
+              : (originalEvent as TouchEvent).touches[0].clientX;
+          startY =
+            "clientY" in originalEvent
+              ? originalEvent.clientY
+              : (originalEvent as TouchEvent).touches[0].clientY;
+
+          wasDraggingRef.current = false;
+          map.dragging.disable(); // Immediately prevent map pan
+
+          pressTimerRef.current = setTimeout(() => {
+            // Long press confirmed
+            wasDraggingRef.current = true; // disable click
+            routeDragRef.current.active = true;
+            routeDragRef.current.startStation = f;
+
+            if (rubberBandLayerRef.current)
+              rubberBandLayerRef.current.clearLayers();
+
+            const startLat = f.geometry.coordinates[1];
+            const startLng = f.geometry.coordinates[0];
+            const routeColor = "#ec4899"; // default active color
+
+            const rubberLine = L.polyline(
+              [
+                [startLat, startLng],
+                [startLat, startLng],
+              ],
+              {
+                color: routeColor,
+                weight: 6,
+                opacity: 0.8,
+                lineCap: "round",
+                dashArray: "8, 8",
+                className: "rubber-band-line",
+              },
+            ).addTo(rubberBandLayerRef.current!);
+
+            const snapCircleCenter = L.circleMarker([0, 0], {
+              radius: 8,
+              color: "#fff",
+              weight: 3,
+              fillColor: routeColor,
+              fillOpacity: 1,
+              opacity: 0,
+            }).addTo(rubberBandLayerRef.current!);
+
+            routeDragRef.current.rubberLine = rubberLine;
+            routeDragRef.current.snapCircleCenter = snapCircleCenter;
+          }, 300); // 300ms long press
+        };
+
+        const handlePointerMove = (e: L.LeafletEvent | L.LeafletMouseEvent) => {
+          if (pressTimerRef.current && !routeDragRef.current.active) {
+            const me = e as L.LeafletMouseEvent;
+            const originalEvent = me.originalEvent as MouseEvent | TouchEvent;
+            const currentX =
+              "clientX" in originalEvent
+                ? originalEvent.clientX
+                : (originalEvent as TouchEvent).touches[0].clientX;
+            const currentY =
+              "clientY" in originalEvent
+                ? originalEvent.clientY
+                : (originalEvent as TouchEvent).touches[0].clientY;
+
+            // 15px tolerance
+            if (
+              Math.abs(currentX - startX) > 15 ||
+              Math.abs(currentY - startY) > 15
+            ) {
+              clearTimeout(pressTimerRef.current);
+              pressTimerRef.current = null;
+              map.dragging.enable();
+            }
+          }
+        };
+
+        const handlePointerUp = (e: L.LeafletEvent | L.LeafletMouseEvent) => {
+          if (pressTimerRef.current) {
+            clearTimeout(pressTimerRef.current);
+            pressTimerRef.current = null;
+
+            // If it wasn't a long press and active drag didn't start, re-enable dragging
+            if (!routeDragRef.current.active) {
+              map.dragging.enable();
+            }
+          }
+        };
+
+        layer.on("mousedown", handlePointerDown);
+        layer.on("touchstart", handlePointerDown);
+        layer.on("mousemove", handlePointerMove);
+        layer.on("touchmove", handlePointerMove);
+        layer.on("mouseup", handlePointerUp);
+        layer.on("touchend", handlePointerUp);
+
+        layer.on("click", (e: L.LeafletMouseEvent) => {
+          L.DomEvent.stopPropagation(e);
+
+          const originalEvent = e.originalEvent as MouseEvent | TouchEvent;
+          const x =
+            "clientX" in originalEvent
+              ? originalEvent.clientX
+              : (originalEvent as TouchEvent).touches[0].clientX;
+          const y =
+            "clientY" in originalEvent
+              ? originalEvent.clientY
+              : (originalEvent as TouchEvent).touches[0].clientY;
+
+          // If was dragged heavily, ignore click
+          if (
+            wasDraggingRef.current &&
+            (Math.abs(x - startX) > 15 || Math.abs(y - startY) > 15)
+          ) {
+            wasDraggingRef.current = false;
+            return;
+          }
+          wasDraggingRef.current = false;
+
+          setStationMenu({
+            x,
+            y,
+            stationData: {
+              name_ja: f.properties.name || "",
+              lat: f.geometry.coordinates[1],
+              lng: f.geometry.coordinates[0],
+            },
+          });
+        });
+        return layer;
+      },
+      (layer, f) => {
+        const marker = layer as any;
+        const stationId =
+          f.properties.id ||
+          `${f.properties.company}:${f.properties.line}:${f.properties.name}`;
+        const isVisited = visitedStationsRef.current.has(stationId);
+        const lineColor = f.properties.stroke || "#64748b";
+        const newLat = f.geometry.coordinates[1];
+        const newLng = f.geometry.coordinates[0];
+        const newName = f.properties.name;
+
+        let changed = false;
+        if (marker._cachedLat !== newLat || marker._cachedLng !== newLng) {
+          marker.setLatLng([newLat, newLng]);
+          marker._cachedLat = newLat;
+          marker._cachedLng = newLng;
+          changed = true;
+        }
+
+        if (marker._cachedName !== newName) {
+          marker.unbindTooltip();
+          if (newName) marker.bindTooltip(newName);
+          marker._cachedName = newName;
+          changed = true;
+        }
+
+        const targetRadius = isVisited
+          ? baseVisitedRadius
+          : baseUnvisitedRadius;
+        const targetWeight = isVisited ? baseVisitedWeight : 0;
+
+        if (
+          marker._cachedIsVisited !== isVisited ||
+          marker._cachedRadius !== targetRadius ||
+          marker._cachedWeight !== targetWeight
+        ) {
+          marker.setStyle({
+            radius: targetRadius,
+            color: isVisited ? "#ffffff" : "transparent",
+            fillColor: isVisited ? lineColor : "#64748b",
+            fillOpacity: isVisited ? 1.0 : 0.5,
+            weight: targetWeight,
+          });
+
+          // Changing panes in Leaflet requires removing and re-adding the layer to its parent layer group.
+          // Since identity now includes the visited state (v/b suffix),
+          // this branch will technically never be hit if isVisited changes,
+          // as syncLeafletLayerGroup will remove the old marker and create a new one.
+          // This is intended because transferring an SVG path node between SVG parent renderers
+          // in Leaflet is error-prone.
+          marker._cachedIsVisited = isVisited;
+          marker._cachedRadius = targetRadius;
+          marker._cachedWeight = targetWeight;
+          changed = true;
+        }
+
+        // Do nothing else if not changed to optimize DOM updates
+      },
+    );
+  };
+
+  const renderBaseMap = (data: CustomFeatureCollection) => {
+    if (!baseLinesLayer.current) return;
+    baseLinesLayer.current.clearLayers();
+
+    // Base Lines
+    const lineFeatures = data.features.filter(
+      (f: CustomGeoJSONFeature) =>
+        f.geometry.type === "LineString" ||
+        f.geometry.type === "MultiLineString",
+    );
+    L.geoJSON(lineFeatures as any, {
+      style: { color: "#475569", weight: 1, opacity: 0.3 },
+      pane: "baseLinesPane",
+      interactive: false,
+      // @ts-ignore
+      renderer: baseLinesRendererRef.current,
+    }).addTo(baseLinesLayer.current);
+  };
+
+  const renderTripRoutes = () => {
+    if (!routeLayer.current || !tripSegmentsGeometry) return;
+
+    const currentZoom = useStore.getState().mapZoom;
+    const zoomWeight =
+      currentZoom < 8 ? 2 : currentZoom < 12 ? 4 : currentZoom < 15 ? 6 : 9;
+
+    interface RouteItem {
+      id: string;
+      coords: any[];
+      color: string;
+      popup: string;
+      fallback: boolean;
+      isTransfer?: boolean;
+    }
+    const routeItems: RouteItem[] = [];
+
+    tripSegmentsGeometry.forEach((seg: any) => {
+      if (seg.isMulti) {
+        seg.coords.forEach((part: any[], index: number) => {
+          routeItems.push({
+            id: `${seg.id}_part_${index}`,
+            coords: part,
+            color: seg.color,
+            popup: seg.popup,
+            fallback: seg.fallback,
+            isTransfer: seg.isTransfer,
+          });
+        });
+      } else {
+        routeItems.push({
+          id: seg.id,
+          coords: seg.coords,
+          color: seg.color,
+          popup: seg.popup,
+          fallback: seg.fallback,
+          isTransfer: seg.isTransfer,
+        });
+      }
+    });
+
+    // Add walk paths from trips
+    const trips = useStore.getState().trips;
+    trips.forEach((t) => {
+      if (t.isWalk && t.walkPath) {
+        routeItems.push({
+          id: `walk_${t.id}`,
+          coords: t.walkPath,
+          color: t.walkType === "tree" ? "#16a34a" : "#9333ea", // Green vs Purple
+          popup: `${t.walkType === "tree" ? "环保/步行" : "UFO/步行"}: ${t.date}`,
+          fallback: true, // Forces dashArray '5, 10' later in the sync renderer
+        });
+      }
+    });
+
+    syncLeafletLayerGroup<RouteItem>(
+      routeLayer.current,
+      routeItems,
+      (item) => item.id,
+      (item) => {
+        const isTransfer = item.isTransfer;
+        const options = {
+          renderer: routeRendererRef.current,
+          color: item.color,
+          weight: zoomWeight,
+          opacity: isTransfer ? 0.5 : 0.9,
+          lineCap: "round",
+          smoothFactor: 0.2,
+          dashArray: item.fallback ? "5, 10" : isTransfer ? "4, 8" : undefined,
+          pane: "routePane",
+        };
+        const pl = L.polyline(
+          item.coords,
+          options as L.PolylineOptions,
+        ).bindPopup(item.popup);
+        (pl as any)._cachedCoords = item.coords;
+        return pl;
+      },
+      (layer, item) => {
+        const pl = layer as L.Polyline & { _cachedCoords?: any[] };
+
+        // setLatLngs is an extremely expensive operation in Leaflet.
+        // Only call it if the coordinates actually changed (reference check).
+        if (pl._cachedCoords !== item.coords) {
+          pl.setLatLngs(item.coords);
+          pl._cachedCoords = item.coords;
+        }
+
+        // setStyle triggers DOM updates. Check before applying.
+        const currentWeight = (pl.options as L.PolylineOptions).weight;
+        const currentColor = (pl.options as L.PolylineOptions).color;
+        const currentDash = (pl.options as L.PolylineOptions).dashArray;
+        const currentOpacity = (pl.options as L.PolylineOptions).opacity;
+
+        const isTransfer = item.isTransfer;
+        const targetDash = item.fallback
+          ? "5, 10"
+          : isTransfer
+            ? "4, 8"
+            : undefined;
+        const targetOpacity = isTransfer ? 0.5 : 0.9;
+
+        if (
+          currentWeight !== zoomWeight ||
+          currentColor !== item.color ||
+          currentDash !== targetDash ||
+          currentOpacity !== targetOpacity
+        ) {
+          pl.setStyle({
+            color: item.color,
+            weight: zoomWeight,
+            dashArray: targetDash,
+            opacity: targetOpacity,
+          });
+        }
+
+        if (pl.getPopup()?.getContent() !== item.popup) {
+          pl.bindPopup(item.popup);
+        }
+      },
+    );
+  };
+
+  const renderPins = () => {
+    if (!pinsLayer.current) return;
+
+    const list = editingPin
+      ? [...pins.filter((p) => p.id !== editingPin.id), editingPin]
+      : pins;
+
+    syncLeafletLayerGroup(
+      pinsLayer.current,
+      list,
+      (pin) => pin.id,
+      (pin) => {
+        const isEditing = editingPin?.id === pin.id;
+        const icon = L.divIcon({
+          className: "pin-marker-icon",
+          html: `<div class="pin-content ${isEditing ? "dragging" : ""}" style="background:${pin.color}; border-color:${isEditing ? "#ffff00" : "white"}; transform:${isEditing ? "scale(1.2) rotate(45deg)" : ""}"> ${pin.type === "photo" ? '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3"><path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"/><circle cx="12" cy="13" r="4"/></svg>' : '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>'} </div>`,
+          iconSize: [32, 32],
+          iconAnchor: [16, 32],
         });
 
-        syncLeafletLayerGroup<CustomGeoJSONFeature>(
-            baseStationsLayer.current,
-            stationFeatures,
-            (f) => {
-                const stationId = f.properties.id || `${f.properties.company}:${f.properties.line}:${f.properties.name}`;
-                const isVisited = visitedStationsRef.current.has(stationId);
-                // Changing panes requires a different renderer. To avoid issues with Leaflet transferring SVG nodes,
-                // we treat a station moving between visited/base as a different entity id.
-                return `${stationId}_${isVisited ? 'v' : 'b'}`;
-            },
-            (f) => {
-                const latlng = [f.geometry.coordinates[1], f.geometry.coordinates[0]] as [number, number];
-                const stationId = f.properties.id || `${f.properties.company}:${f.properties.line}:${f.properties.name}`;
-                const isVisited = visitedStationsRef.current.has(stationId);
-                const lineColor = f.properties.stroke || '#64748b'; // Fallback if no stroke defined
-
-                const targetRadius = isVisited ? baseVisitedRadius : baseUnvisitedRadius;
-                const targetWeight = isVisited ? baseVisitedWeight : 0;
-
-                const currentRenderer = isVisited ? visitedStationsRendererRef.current! : baseStationsRendererRef.current!;
-
-                const layer = L.circleMarker(latlng, {
-                    renderer: currentRenderer,
-                    radius: targetRadius,
-                    color: isVisited ? '#ffffff' : 'transparent',
-                    fillColor: isVisited ? lineColor : '#64748b',
-                    fillOpacity: isVisited ? 1.0 : 0.5,
-                    weight: targetWeight,
-                    className: 'station-dot',
-                    pane: isVisited ? 'visitedStationsPane' : 'baseStationsPane'
-                });
-                // @ts-ignore
-                layer._cachedIsVisited = isVisited;
-                if (f.properties.name) layer.bindTooltip(f.properties.name);
-
-                // @ts-ignore
-                layer._cachedLat = latlng[0];
-                // @ts-ignore
-                layer._cachedLng = latlng[1];
-                // @ts-ignore
-                layer._cachedName = f.properties.name;
-                // @ts-ignore
-                layer._cachedRadius = targetRadius;
-                // @ts-ignore
-                layer._cachedWeight = targetWeight;
-
-                let startX = 0;
-                let startY = 0;
-
-                const handlePointerDown = (e: L.LeafletEvent | L.LeafletMouseEvent) => {
-                    L.DomEvent.stopPropagation(e);
-
-                    if (pressTimerRef.current) clearTimeout(pressTimerRef.current);
-
-                    const me = e as L.LeafletMouseEvent;
-                    const originalEvent = me.originalEvent as MouseEvent | TouchEvent;
-                    startX = 'clientX' in originalEvent ? originalEvent.clientX : (originalEvent as TouchEvent).touches[0].clientX;
-                    startY = 'clientY' in originalEvent ? originalEvent.clientY : (originalEvent as TouchEvent).touches[0].clientY;
-
-                    wasDraggingRef.current = false;
-                    map.dragging.disable(); // Immediately prevent map pan
-
-                    pressTimerRef.current = setTimeout(() => {
-                        // Long press confirmed
-                        wasDraggingRef.current = true; // disable click
-                        routeDragRef.current.active = true;
-                        routeDragRef.current.startStation = f;
-
-                        if (rubberBandLayerRef.current) rubberBandLayerRef.current.clearLayers();
-
-                        const startLat = f.geometry.coordinates[1];
-                        const startLng = f.geometry.coordinates[0];
-                        const routeColor = '#ec4899'; // default active color
-
-                        const rubberLine = L.polyline([[startLat, startLng], [startLat, startLng]], {
-                            color: routeColor,
-                            weight: 6,
-                            opacity: 0.8,
-                            lineCap: 'round',
-                            dashArray: '8, 8',
-                            className: 'rubber-band-line'
-                        }).addTo(rubberBandLayerRef.current!);
-
-                        const snapCircleCenter = L.circleMarker([0, 0], {
-                            radius: 8,
-                            color: '#fff',
-                            weight: 3,
-                            fillColor: routeColor,
-                            fillOpacity: 1,
-                            opacity: 0
-                        }).addTo(rubberBandLayerRef.current!);
-
-                        routeDragRef.current.rubberLine = rubberLine;
-                        routeDragRef.current.snapCircleCenter = snapCircleCenter;
-
-                    }, 300); // 300ms long press
-                };
-
-                const handlePointerMove = (e: L.LeafletEvent | L.LeafletMouseEvent) => {
-                    if (pressTimerRef.current && !routeDragRef.current.active) {
-                        const me = e as L.LeafletMouseEvent;
-                        const originalEvent = me.originalEvent as MouseEvent | TouchEvent;
-                        const currentX = 'clientX' in originalEvent ? originalEvent.clientX : (originalEvent as TouchEvent).touches[0].clientX;
-                        const currentY = 'clientY' in originalEvent ? originalEvent.clientY : (originalEvent as TouchEvent).touches[0].clientY;
-
-                        // 15px tolerance
-                        if (Math.abs(currentX - startX) > 15 || Math.abs(currentY - startY) > 15) {
-                            clearTimeout(pressTimerRef.current);
-                            pressTimerRef.current = null;
-                            map.dragging.enable();
-                        }
-                    }
-                };
-
-                const handlePointerUp = (e: L.LeafletEvent | L.LeafletMouseEvent) => {
-                    if (pressTimerRef.current) {
-                        clearTimeout(pressTimerRef.current);
-                        pressTimerRef.current = null;
-
-                        // If it wasn't a long press and active drag didn't start, re-enable dragging
-                        if (!routeDragRef.current.active) {
-                            map.dragging.enable();
-                        }
-                    }
-                };
-
-                layer.on('mousedown', handlePointerDown);
-                layer.on('touchstart', handlePointerDown);
-                layer.on('mousemove', handlePointerMove);
-                layer.on('touchmove', handlePointerMove);
-                layer.on('mouseup', handlePointerUp);
-                layer.on('touchend', handlePointerUp);
-
-                layer.on('click', (e: L.LeafletMouseEvent) => {
-                    L.DomEvent.stopPropagation(e);
-
-                    const originalEvent = e.originalEvent as MouseEvent | TouchEvent;
-                    const x = 'clientX' in originalEvent ? originalEvent.clientX : (originalEvent as TouchEvent).touches[0].clientX;
-                    const y = 'clientY' in originalEvent ? originalEvent.clientY : (originalEvent as TouchEvent).touches[0].clientY;
-
-                    // If was dragged heavily, ignore click
-                    if (wasDraggingRef.current && (Math.abs(x - startX) > 15 || Math.abs(y - startY) > 15)) {
-                        wasDraggingRef.current = false;
-                        return;
-                    }
-                    wasDraggingRef.current = false;
-
-                    setStationMenu({ x, y, stationData: { name_ja: f.properties.name || '', lat: f.geometry.coordinates[1], lng: f.geometry.coordinates[0] } });
-                });
-                return layer;
-            },
-            (layer, f) => {
-                const marker = layer as any;
-                const stationId = f.properties.id || `${f.properties.company}:${f.properties.line}:${f.properties.name}`;
-                const isVisited = visitedStationsRef.current.has(stationId);
-                const lineColor = f.properties.stroke || '#64748b';
-                const newLat = f.geometry.coordinates[1];
-                const newLng = f.geometry.coordinates[0];
-                const newName = f.properties.name;
-
-                let changed = false;
-                if (marker._cachedLat !== newLat || marker._cachedLng !== newLng) {
-                    marker.setLatLng([newLat, newLng]);
-                    marker._cachedLat = newLat;
-                    marker._cachedLng = newLng;
-                    changed = true;
-                }
-
-                if (marker._cachedName !== newName) {
-                    marker.unbindTooltip();
-                    if (newName) marker.bindTooltip(newName);
-                    marker._cachedName = newName;
-                    changed = true;
-                }
-
-                const targetRadius = isVisited ? baseVisitedRadius : baseUnvisitedRadius;
-                const targetWeight = isVisited ? baseVisitedWeight : 0;
-
-                if (marker._cachedIsVisited !== isVisited || marker._cachedRadius !== targetRadius || marker._cachedWeight !== targetWeight) {
-                    marker.setStyle({
-                        radius: targetRadius,
-                        color: isVisited ? '#ffffff' : 'transparent',
-                        fillColor: isVisited ? lineColor : '#64748b',
-                        fillOpacity: isVisited ? 1.0 : 0.5,
-                        weight: targetWeight
-                    });
-
-                    // Changing panes in Leaflet requires removing and re-adding the layer to its parent layer group.
-                    // Since identity now includes the visited state (v/b suffix),
-                    // this branch will technically never be hit if isVisited changes,
-                    // as syncLeafletLayerGroup will remove the old marker and create a new one.
-                    // This is intended because transferring an SVG path node between SVG parent renderers
-                    // in Leaflet is error-prone.
-                    marker._cachedIsVisited = isVisited;
-                    marker._cachedRadius = targetRadius;
-                    marker._cachedWeight = targetWeight;
-                    changed = true;
-                }
-
-                // Do nothing else if not changed to optimize DOM updates
-            }
-        );
-    };
-
-
-    const renderBaseMap = (data: CustomFeatureCollection) => {
-        if (!baseLinesLayer.current) return;
-        baseLinesLayer.current.clearLayers();
-
-        // Base Lines
-        const lineFeatures = data.features.filter((f: CustomGeoJSONFeature) => f.geometry.type === 'LineString' || f.geometry.type === 'MultiLineString');
-        L.geoJSON(lineFeatures as any, {
-            style: { color: '#475569', weight: 1, opacity: 0.3 },
-            pane: 'baseLinesPane',
-            interactive: false,
-            // @ts-ignore
-            renderer: baseLinesRendererRef.current
-        }).addTo(baseLinesLayer.current);
-    };
-
-    const renderTripRoutes = () => {
-        if (!routeLayer.current || !tripSegmentsGeometry) return;
-
-        const currentZoom = useStore.getState().mapZoom;
-        const zoomWeight = currentZoom < 8 ? 2 : currentZoom < 12 ? 4 : currentZoom < 15 ? 6 : 9;
-
-        interface RouteItem { id: string, coords: any[], color: string, popup: string, fallback: boolean, isTransfer?: boolean }
-        const routeItems: RouteItem[] = [];
-
-        tripSegmentsGeometry.forEach((seg: any) => {
-            if (seg.isMulti) {
-                seg.coords.forEach((part: any[], index: number) => {
-                    routeItems.push({ id: `${seg.id}_part_${index}`, coords: part, color: seg.color, popup: seg.popup, fallback: seg.fallback, isTransfer: seg.isTransfer });
-                });
-            } else {
-                routeItems.push({ id: seg.id, coords: seg.coords, color: seg.color, popup: seg.popup, fallback: seg.fallback, isTransfer: seg.isTransfer });
-            }
+        const marker = L.marker([pin.lat, pin.lng], {
+          icon,
+          draggable: true,
+          zIndexOffset: isEditing ? 1000 : 0,
         });
-
-        // Add walk paths from trips
-        const trips = useStore.getState().trips;
-        trips.forEach(t => {
-            if (t.isWalk && t.walkPath) {
-                routeItems.push({
-                    id: `walk_${t.id}`,
-                    coords: t.walkPath,
-                    color: t.walkType === 'tree' ? '#16a34a' : '#9333ea', // Green vs Purple
-                    popup: `${t.walkType === 'tree' ? '环保/步行' : 'UFO/步行'}: ${t.date}`,
-                    fallback: true // Forces dashArray '5, 10' later in the sync renderer
-                });
-            }
+        marker.on("dragstart", () => {
+          isDraggingRef.current = true;
+          setEditingPin({ ...pin });
+          const currentPinMode = useStore.getState().pinMode;
+          if (currentPinMode === PinMode.Idle) setPinMode(PinMode.Free);
         });
+        marker.on("dragend", (e) => {
+          isDraggingRef.current = false;
+          const { lat, lng } = e.target.getLatLng();
+          let newPos = {
+            lat,
+            lng,
+            lineKey: pin.lineKey,
+            percentage: pin.percentage,
+          };
+          const currentPinMode = useStore.getState().pinMode;
+          if (currentPinMode === PinMode.Snap) {
+            const snap = findNearestPointOnLine(
+              useStore.getState().railwayData,
+              lat,
+              lng,
+            );
+            newPos = { ...newPos, ...snap };
+            e.target.setLatLng(newPos);
+          }
+          setEditingPin((prev) =>
+            prev && prev.id === pin.id
+              ? { ...prev, ...newPos }
+              : { ...pin, ...newPos },
+          );
+          if (currentPinMode === PinMode.Idle) setPinMode(PinMode.Free);
+        });
+        marker.on("click", () => {
+          setEditingPin(pin);
+          const currentPinMode = useStore.getState().pinMode;
+          if (currentPinMode === PinMode.Idle) setPinMode(PinMode.Free);
+        });
+        return marker;
+      },
+      (layer, pin) => {
+        const marker = layer as L.Marker & {
+          _cachedLat?: number;
+          _cachedLng?: number;
+          _cachedIsEditing?: boolean;
+          _cachedColor?: string;
+        };
+        const isEditing = editingPin?.id === pin.id;
 
-        syncLeafletLayerGroup<RouteItem>(
-            routeLayer.current,
-            routeItems,
-            (item) => item.id,
-            (item) => {
-                const isTransfer = item.isTransfer;
-                const options = {
-                    renderer: routeRendererRef.current,
-                    color: item.color,
-                    weight: zoomWeight,
-                    opacity: isTransfer ? 0.5 : 0.9,
-                    lineCap: 'round',
-                    smoothFactor: 0.2,
-                    dashArray: item.fallback ? '5, 10' : (isTransfer ? '4, 8' : undefined),
-                    pane: 'routePane'
-                };
-                const pl = L.polyline(item.coords, options as L.PolylineOptions).bindPopup(item.popup);
-                (pl as any)._cachedCoords = item.coords;
-                return pl;
-            },
-            (layer, item) => {
-                const pl = layer as L.Polyline & { _cachedCoords?: any[] };
+        if (marker._cachedLat !== pin.lat || marker._cachedLng !== pin.lng) {
+          marker.setLatLng([pin.lat, pin.lng]);
+          marker._cachedLat = pin.lat;
+          marker._cachedLng = pin.lng;
+        }
 
-                // setLatLngs is an extremely expensive operation in Leaflet.
-                // Only call it if the coordinates actually changed (reference check).
-                if (pl._cachedCoords !== item.coords) {
-                    pl.setLatLngs(item.coords);
-                    pl._cachedCoords = item.coords;
-                }
+        if (
+          marker._cachedIsEditing !== isEditing ||
+          marker._cachedColor !== pin.color
+        ) {
+          const icon = L.divIcon({
+            className: "pin-marker-icon",
+            html: `<div class="pin-content ${isEditing ? "dragging" : ""}" style="background:${pin.color}; border-color:${isEditing ? "#ffff00" : "white"}; transform:${isEditing ? "scale(1.2) rotate(45deg)" : ""}"> ${pin.type === "photo" ? '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3"><path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"/><circle cx="12" cy="13" r="4"/></svg>' : '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>'} </div>`,
+            iconSize: [32, 32],
+            iconAnchor: [16, 32],
+          });
+          marker.setIcon(icon);
+          marker.setZIndexOffset(isEditing ? 1000 : 0);
 
-                // setStyle triggers DOM updates. Check before applying.
-                const currentWeight = (pl.options as L.PolylineOptions).weight;
-                const currentColor = (pl.options as L.PolylineOptions).color;
-                const currentDash = (pl.options as L.PolylineOptions).dashArray;
-                const currentOpacity = (pl.options as L.PolylineOptions).opacity;
+          marker._cachedIsEditing = isEditing;
+          marker._cachedColor = pin.color;
+        }
+      },
+    );
+  };
 
-                const isTransfer = item.isTransfer;
-                const targetDash = item.fallback ? '5, 10' : (isTransfer ? '4, 8' : undefined);
-                const targetOpacity = isTransfer ? 0.5 : 0.9;
-
-                if (currentWeight !== zoomWeight || currentColor !== item.color || currentDash !== targetDash || currentOpacity !== targetOpacity) {
-                    pl.setStyle({ color: item.color, weight: zoomWeight, dashArray: targetDash, opacity: targetOpacity });
-                }
-
-                if (pl.getPopup()?.getContent() !== item.popup) {
-                    pl.bindPopup(item.popup);
-                }
-            }
-        );
-    };
-
-    const renderPins = () => {
-        if (!pinsLayer.current) return;
-
-        const list = editingPin ? [...pins.filter(p => p.id !== editingPin.id), editingPin] : pins;
-
-        syncLeafletLayerGroup(
-            pinsLayer.current,
-            list,
-            (pin) => pin.id,
-            (pin) => {
-                const isEditing = editingPin?.id === pin.id;
-                const icon = L.divIcon({ className: 'pin-marker-icon', html: `<div class="pin-content ${isEditing ? 'dragging' : ''}" style="background:${pin.color}; border-color:${isEditing ? '#ffff00' : 'white'}; transform:${isEditing ? 'scale(1.2) rotate(45deg)' : ''}"> ${pin.type === 'photo' ? '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3"><path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"/><circle cx="12" cy="13" r="4"/></svg>' : '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>'} </div>`, iconSize: [32, 32], iconAnchor: [16, 32] });
-
-                const marker = L.marker([pin.lat, pin.lng], { icon, draggable: true, zIndexOffset: isEditing ? 1000 : 0 });
-                marker.on('dragstart', () => {
-                    isDraggingRef.current = true;
-                    setEditingPin({ ...pin });
-                    const currentPinMode = useStore.getState().pinMode;
-                    if (currentPinMode === PinMode.Idle) setPinMode(PinMode.Free);
-                });
-                marker.on('dragend', (e) => {
-                    isDraggingRef.current = false;
-                    const { lat, lng } = e.target.getLatLng();
-                    let newPos = { lat, lng, lineKey: pin.lineKey, percentage: pin.percentage };
-                    const currentPinMode = useStore.getState().pinMode;
-                    if (currentPinMode === PinMode.Snap) {
-                        const snap = findNearestPointOnLine(useStore.getState().railwayData, lat, lng);
-                        newPos = { ...newPos, ...snap };
-                        e.target.setLatLng(newPos);
-                    }
-                    setEditingPin((prev) => prev && prev.id === pin.id ? { ...prev, ...newPos } : { ...pin, ...newPos });
-                    if (currentPinMode === PinMode.Idle) setPinMode(PinMode.Free);
-                });
-                marker.on('click', () => {
-                    setEditingPin(pin);
-                    const currentPinMode = useStore.getState().pinMode;
-                    if (currentPinMode === PinMode.Idle) setPinMode(PinMode.Free);
-                });
-                return marker;
-            },
-            (layer, pin) => {
-                const marker = layer as L.Marker & { _cachedLat?: number, _cachedLng?: number, _cachedIsEditing?: boolean, _cachedColor?: string };
-                const isEditing = editingPin?.id === pin.id;
-
-                if (marker._cachedLat !== pin.lat || marker._cachedLng !== pin.lng) {
-                    marker.setLatLng([pin.lat, pin.lng]);
-                    marker._cachedLat = pin.lat;
-                    marker._cachedLng = pin.lng;
-                }
-
-                if (marker._cachedIsEditing !== isEditing || marker._cachedColor !== pin.color) {
-                    const icon = L.divIcon({ className: 'pin-marker-icon', html: `<div class="pin-content ${isEditing ? 'dragging' : ''}" style="background:${pin.color}; border-color:${isEditing ? '#ffff00' : 'white'}; transform:${isEditing ? 'scale(1.2) rotate(45deg)' : ''}"> ${pin.type === 'photo' ? '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3"><path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"/><circle cx="12" cy="13" r="4"/></svg>' : '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>'} </div>`, iconSize: [32, 32], iconAnchor: [16, 32] });
-                    marker.setIcon(icon);
-                    marker.setZIndexOffset(isEditing ? 1000 : 0);
-
-                    marker._cachedIsEditing = isEditing;
-                    marker._cachedColor = pin.color;
-                }
-            }
-        );
-    };
-
-    return <div ref={mapRef} style={{ width: '100%', height: '100%' }} />;
+  return <div ref={mapRef} style={{ width: "100%", height: "100%" }} />;
 };

--- a/src/components/map/MapContainer.tsx
+++ b/src/components/map/MapContainer.tsx
@@ -207,16 +207,24 @@ export const MapContainer: React.FC<Props> = ({
       const handleShowNearbyStations = (e: Event) => {
         const customEvent = e as CustomEvent;
         const { stations } = customEvent.detail;
-        if (stations && stations.length > 0) {
-            // For now, let's open the closest one in the station menu
+        if (stations && stations.length > 0 && mapInstance.current) {
+            const map = mapInstance.current;
             const closest = stations[0];
-            const point = mapInstance.current?.latLngToContainerPoint([closest.station.lat, closest.station.lng]);
-            if (point) {
-                 setStationMenu({
+
+            // Wait for flyTo to finish before calculating container point
+            const setMenu = () => {
+                const point = map.latLngToContainerPoint([closest.station.lat, closest.station.lng]);
+                setStationMenu({
                     x: point.x,
                     y: point.y,
                     stationData: closest.station
-                 });
+                });
+            };
+
+            if ((map as any)._isLocateFlying) {
+                map.once("moveend", setMenu);
+            } else {
+                setMenu();
             }
         }
       };

--- a/src/components/map/MapContainer.tsx
+++ b/src/components/map/MapContainer.tsx
@@ -204,11 +204,30 @@ export const MapContainer: React.FC<Props> = ({
       }, 1100);
     };
 
+      const handleShowNearbyStations = (e: Event) => {
+        const customEvent = e as CustomEvent;
+        const { stations } = customEvent.detail;
+        if (stations && stations.length > 0) {
+            // For now, let's open the closest one in the station menu
+            const closest = stations[0];
+            const point = mapInstance.current?.latLngToContainerPoint([closest.station.lat, closest.station.lng]);
+            if (point) {
+                 setStationMenu({
+                    x: point.x,
+                    y: point.y,
+                    stationData: closest.station
+                 });
+            }
+        }
+      };
+
     window.addEventListener("map:create-temp-pin", handleCreateTempPin);
     window.addEventListener("map:fly-to-location", handleFlyToLocation);
+      window.addEventListener("map:show-nearby-stations", handleShowNearbyStations);
     return () => {
       window.removeEventListener("map:create-temp-pin", handleCreateTempPin);
       window.removeEventListener("map:fly-to-location", handleFlyToLocation);
+        window.removeEventListener("map:show-nearby-stations", handleShowNearbyStations);
     };
   }, [setEditingPin]);
 

--- a/src/core/railwayRouting.ts.orig
+++ b/src/core/railwayRouting.ts.orig
@@ -45,7 +45,7 @@ export const getTransferableLines = (station: Station | undefined, currentLineKe
             if (railwayData[lineKey]) {
                 const nextMeta = railwayData[lineKey].meta;
                 validLines.add(lineKey);
-                
+
             }
         });
     }
@@ -199,7 +199,7 @@ export const findRoute = (startLineKey: string, startStId: string, endLineKey: s
         if (currentStation.transfers && Array.isArray(currentStation.transfers)) {
             for (const nextLineKey of currentStation.transfers) {
                 if (nextLineKey === current.lineKey) continue;
-                
+
                 const nextLine = railwayData[nextLineKey];
                 if (!nextLine) continue;
 
@@ -395,7 +395,7 @@ export const getLandmarks = (line: any, fromId: string, toId: string, loopVia?: 
         }
 
         checkedCount++;
-        
+
         // 非环线如果越界则停止
         if (!line.meta?.isLoop) {
             if (currIdx === 0 || currIdx === n - 1) break;
@@ -458,24 +458,4 @@ export const findNearestPointOnLine = (railwayData: RailwayMap, targetLat: numbe
     }
 
     return bestPoint;
-};
-
-export const findNearbyStations = (railwayData: RailwayMap, targetLat: number, targetLng: number, limit = 5) => {
-    const stationsList: { lineKey: string, station: any, distSq: number }[] = [];
-
-    for (const lineKey in railwayData) {
-        if (!Object.prototype.hasOwnProperty.call(railwayData, lineKey)) continue;
-        const line = railwayData[lineKey];
-        if (!line.stations) continue;
-
-        for (const station of line.stations) {
-            const dSq = (targetLat - station.lat) ** 2 + (targetLng - station.lng) ** 2;
-            stationsList.push({ lineKey, station, distSq: dSq });
-        }
-    }
-
-    stationsList.sort((a, b) => a.distSq - b.distSq);
-
-    // Extract up to `limit` unique stations by ID/Name, or just the top 5
-    return stationsList.slice(0, limit);
 };

--- a/src/core/railwayRouting.ts.patch
+++ b/src/core/railwayRouting.ts.patch
@@ -1,0 +1,26 @@
+--- src/core/railwayRouting.ts
++++ src/core/railwayRouting.ts
+@@ -467,3 +467,23 @@
+       }
+     return bestPoint;
+ };
++
++export const findNearbyStations = (railwayData: RailwayMap, targetLat: number, targetLng: number, limit = 5) => {
++    const stationsList: { lineKey: string, station: any, distSq: number }[] = [];
++
++    for (const lineKey in railwayData) {
++        if (!Object.prototype.hasOwnProperty.call(railwayData, lineKey)) continue;
++        const line = railwayData[lineKey];
++        if (!line.stations) continue;
++
++        for (const station of line.stations) {
++            const dSq = (targetLat - station.lat) ** 2 + (targetLng - station.lng) ** 2;
++            stationsList.push({ lineKey, station, distSq: dSq });
++        }
++    }
++
++    stationsList.sort((a, b) => a.distSq - b.distSq);
++
++    // Extract up to `limit` unique stations by ID/Name, or just the top 5
++    return stationsList.slice(0, limit);
++};


### PR DESCRIPTION
This PR introduces the standard map location action button in the bottom right corner of the Map view. It hooks into the Geolocation API to fly the map to the user's location with a clean loading spinner state. On success, consecutive clicks cycle through zoom levels 14, 16, and 18. Actual user drag/scroll interactions cleanly abort this focus state to return it to 'idle'.

---
*PR created automatically by Jules for task [4851295173029808605](https://jules.google.com/task/4851295173029808605) started by @OsakaLOOP*