### PR TITLE
Optimize Blog and App Navigation with Tabs API Logic

### DIFF
--- a/blog/src/components/Footer.astro
+++ b/blog/src/components/Footer.astro
@@ -5,7 +5,7 @@ import { APP_URL, SITE_TITLE } from '../consts';
   <div class="footer-inner">
     <span>{SITE_TITLE} &copy; {new Date().getFullYear()}</span>
     <div class="footer-links">
-      <a href={APP_URL}>返回应用</a>
+      <a href={APP_URL} class="app-return-link">返回应用</a>
       <a href="/blog/">日志</a>
       <a href="/blog/about/">关于</a>
       <a href="/blog/rss.xml">RSS</a>
@@ -41,3 +41,18 @@ import { APP_URL, SITE_TITLE } from '../consts';
   }
   .footer-links a:hover { color: #39C5BB; }
 </style>
+
+
+<script>
+  document.addEventListener('click', function(e) {
+    var target = e.target.closest('a.app-return-link');
+    if (target) {
+      e.preventDefault();
+      if (window.opener && !window.opener.closed) {
+        window.close();
+      } else {
+        window.location.href = target.href;
+      }
+    }
+  });
+</script>

--- a/blog/src/components/Header.astro
+++ b/blog/src/components/Header.astro
@@ -8,7 +8,7 @@ const base = lang === 'zh-cn' ? '/blog/' : `/blog/${lang}/`;
 <header class="site-header">
   <nav class="header-nav">
     <div class="header-left">
-      <a href={APP_URL} class="back-link" title="返回应用">
+      <a href={APP_URL} class="back-link app-return-link" title="返回应用">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
           <path d="M19 12H5M12 5l-7 7 7 7"/>
         </svg>

--- a/blog/src/pages/[lang]/about.astro
+++ b/blog/src/pages/[lang]/about.astro
@@ -61,7 +61,7 @@ const t = labels[lang] || labels['en'];
     </ul>
 
     <div style="margin-top:3rem;padding-top:1.5rem;border-top:1px solid rgba(255,255,255,0.08)">
-      <a href={APP_URL} style="color:#39C5BB;font-weight:600;display:inline-flex;align-items:center;gap:0.4rem">
+      <a href={APP_URL} class="app-return-link" style="color:#39C5BB;font-weight:600;display:inline-flex;align-items:center;gap:0.4rem">
         ← {t.back}
       </a>
     </div>

--- a/blog/src/pages/about.astro
+++ b/blog/src/pages/about.astro
@@ -27,7 +27,7 @@ import { APP_URL, SITE_TITLE } from '../consts';
     <p>请查看 <a href="/blog/blog/" style="color:var(--accent)">开发日志</a> 了解最新更新动态。</p>
 
     <div style="margin-top:3rem;padding-top:1.5rem;border-top:1px solid var(--border)">
-      <a href={APP_URL} style="color:var(--accent);font-weight:600;display:inline-flex;align-items:center;gap:0.4rem">
+      <a href={APP_URL} class="app-return-link" style="color:var(--accent);font-weight:600;display:inline-flex;align-items:center;gap:0.4rem">
         ← 返回应用
       </a>
     </div>

--- a/src/AppLayout.tsx
+++ b/src/AppLayout.tsx
@@ -99,9 +99,8 @@ export const AppLayout: React.FC = () => {
                     // Normalize lang for blog path (zh-cn, en, ja-jp, zh-tw)
                     let blogLang = currentAppLang;
                     if (blogLang === 'zh-cn') blogLang = 'zh-cn';
-                    // Open in new tab and redirect current tab back to root to avoid empty page
-                    window.open(`/blog/${blogLang}/`, '_blank');
-                    window.location.replace('/');
+                    // Redirect browser to separate Astro mount
+                    window.location.href = `/blog/${blogLang}/`;
                     return;
                 }
                 return; // Skip standard app localization for blog paths

--- a/src/AppLayout.tsx
+++ b/src/AppLayout.tsx
@@ -99,8 +99,9 @@ export const AppLayout: React.FC = () => {
                     // Normalize lang for blog path (zh-cn, en, ja-jp, zh-tw)
                     let blogLang = currentAppLang;
                     if (blogLang === 'zh-cn') blogLang = 'zh-cn';
-                    // Redirect browser to separate Astro mount
-                    window.location.href = `/blog/${blogLang}/`;
+                    // Open in new tab and redirect current tab back to root to avoid empty page
+                    window.open(`/blog/${blogLang}/`, '_blank');
+                    window.location.replace('/');
                     return;
                 }
                 return; // Skip standard app localization for blog paths

--- a/src/components/VersionBadge.jsx
+++ b/src/components/VersionBadge.jsx
@@ -91,6 +91,8 @@ const VersionBadge = ({ version: currentVersion }) => {
             {/* Badge Trigger */}
             <a 
                 href="/blog/"
+                target="_blank"
+                rel="noopener noreferrer"
                 className="cursor-pointer group/badge bg-[#39C5BB] hover:bg-teal-500 transition-colors text-white rounded px-1.5 py-0.5 text-[10px] font-bold ml-2 shadow-sm flex items-center gap-1 relative"
             >
                 <span className="group-hover/badge:hidden">v{currentVersion}</span>
@@ -176,7 +178,7 @@ const VersionBadge = ({ version: currentVersion }) => {
                                                     </div>
                                                     <div className="flex items-center justify-between mt-1">
                                                         <span className="text-[10px] text-gray-300">{log.date}</span>
-                                                        <a href={`/blog/dev/v${log.version}/`} className="invisible group-hover:visible text-[10px] font-bold text-[#39C5BB] hover:text-teal-600 flex items-center gap-1 transition-colors">
+                                                        <a href={`/blog/dev/v${log.version}/`} target="_blank" rel="noopener noreferrer" className="invisible group-hover:visible text-[10px] font-bold text-[#39C5BB] hover:text-teal-600 flex items-center gap-1 transition-colors">
                                                             Detail <ExternalLink size={10}/>
                                                         </a>
                                                     </div>

--- a/src/components/VersionBadge.jsx
+++ b/src/components/VersionBadge.jsx
@@ -92,7 +92,7 @@ const VersionBadge = ({ version: currentVersion }) => {
             <a 
                 href="/blog/"
                 target="_blank"
-                rel="noopener noreferrer"
+                rel="opener"
                 className="cursor-pointer group/badge bg-[#39C5BB] hover:bg-teal-500 transition-colors text-white rounded px-1.5 py-0.5 text-[10px] font-bold ml-2 shadow-sm flex items-center gap-1 relative"
             >
                 <span className="group-hover/badge:hidden">v{currentVersion}</span>
@@ -178,7 +178,7 @@ const VersionBadge = ({ version: currentVersion }) => {
                                                     </div>
                                                     <div className="flex items-center justify-between mt-1">
                                                         <span className="text-[10px] text-gray-300">{log.date}</span>
-                                                        <a href={`/blog/dev/v${log.version}/`} target="_blank" rel="noopener noreferrer" className="invisible group-hover:visible text-[10px] font-bold text-[#39C5BB] hover:text-teal-600 flex items-center gap-1 transition-colors">
+                                                        <a href={`/blog/dev/v${log.version}/`} target="_blank" rel="opener" className="invisible group-hover:visible text-[10px] font-bold text-[#39C5BB] hover:text-teal-600 flex items-center gap-1 transition-colors">
                                                             Detail <ExternalLink size={10}/>
                                                         </a>
                                                     </div>

--- a/src/components/common/ErrorBoundary.tsx
+++ b/src/components/common/ErrorBoundary.tsx
@@ -57,7 +57,7 @@ export class ErrorBoundary extends React.Component<Props, State> {
               <a 
                 href="/blog/"
                 target="_blank"
-                rel="noopener noreferrer"
+                rel="opener"
                 className="flex items-center gap-2 px-5 py-2 bg-white text-slate-600 text-xs font-bold rounded-xl border border-slate-200 transition-all hover:bg-slate-50 active:scale-95 shadow-sm"
               >
                 <Home size={14} /> 返回索引

--- a/src/components/common/ErrorBoundary.tsx
+++ b/src/components/common/ErrorBoundary.tsx
@@ -56,6 +56,8 @@ export class ErrorBoundary extends React.Component<Props, State> {
               </button>
               <a 
                 href="/blog/"
+                target="_blank"
+                rel="noopener noreferrer"
                 className="flex items-center gap-2 px-5 py-2 bg-white text-slate-600 text-xs font-bold rounded-xl border border-slate-200 transition-all hover:bg-slate-50 active:scale-95 shadow-sm"
               >
                 <Home size={14} /> 返回索引


### PR DESCRIPTION
Updates the main application and blog to use separate tabs for navigation to prevent reloading and performance degradation of the main app when accessing the Astro blog. Adds a robust script in the blog to close its tab and return focus to the main app when returning, falling back to a normal redirect if the tab was opened directly.

---
*PR created automatically by Jules for task [184234513697217721](https://jules.google.com/task/184234513697217721) started by @OsakaLOOP*