### PR TITLE
⚡ Bolt: Replace O(n²) station lookups with O(n) hash map in trip lists

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,6 @@
 ## 2024-04-15 - [Avoid O(N log N) Sorting on Massive Geographical Collections]
 **Learning:** In spatial queries like `findNearbyStations` where we scan `railwayData` containing thousands of stations to find the top K nearest points, allocating all elements to an array and running `Array.prototype.sort()` results in massive temporary object allocation and $O(N \log N)$ execution time (taking ~8.5ms in benchmarks).
 **Action:** Replace full array sorts with a bounded Top-K array using a simple $O(K)$ insertion sort during the $O(N)$ iteration phase. This brings the time complexity effectively down to $O(N)$, speeding up operations by ~36x (taking ~0.24ms). Remember to apply a final sort if total elements found are less than $K$.
+## 2024-05-14 - React Rendering Bottleneck with Large Global Objects
+**Learning:** In React components that iterate over lists (like trips), performing nested loops (e.g., `Object.values().forEach()`) across a massive global object (like `railwayData`) to lookup nested IDs (like `station.id`) causes significant O(N x M) rendering latency.
+**Action:** Always decouple lookup operations from render cycles. Create a flat `useMemo` map (e.g., `Map<ID, Entity>`) at the component top level to enable O(1) hash map lookups within the render list iterations.

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,60 @@
+1.  **Analyze the Performance Bottleneck:**
+    *   In `src/pages/TripsPage.tsx` and `src/components/modals/WalkTripEditor.tsx`, there are instances of iterating over the *entire* `railwayData` object (which is a large map of transit lines and their stations) using `Object.values(railwayData).forEach(...)`.
+    *   This is done simply to find a station's name given its ID (`trip.fromId` and `trip.toId`).
+    *   `railwayData` contains hundreds of lines and thousands of stations. Iterating through all of them for every walk trip rendered on the `TripsPage` is an O(N*M) operation (where N is the number of walk trips, and M is the total number of lines, and we also do a `.find` on stations). This is a classic "unnecessary loop" and a very common React rendering bottleneck.
+    *   It's also done inside the `WalkTripEditor` component, both in render and in `onSave`.
+
+2.  **Proposed Optimization:**
+    *   Use a constant-time O(1) lookup map (a `stationIdMap`) to resolve station IDs to their names.
+    *   Since `railwayData` is immutable from Zustand and only updates when loaded, we can construct this `stationMap` once and memoize it, or construct it on the fly efficiently, or just utilize a `useMemo` at the top level of the component.
+    *   Even simpler, since `railwayData` keys *are not* the line keys inside `station.id` directly, we need a flat map of `station.id -> station`.
+    *   Looking at `src/core/railwayRouting.ts`, we see it's possible the `railwayData` isn't huge enough to crash, but doing it inside `.map` of trips is bad.
+    *   Let's create a `useMemo` in `TripsPage.tsx` to build a `Map<string, string>` (ID to name) from `railwayData`.
+    *   Let's do the same for `WalkTripEditor.tsx`.
+
+3.  **Refactoring `TripsPage.tsx`:**
+    *   Add:
+        ```typescript
+        const stationNameMap = useMemo(() => {
+            const map = new Map<string, string>();
+            for (const key in railwayData) {
+                const line = railwayData[key];
+                if (line.stations) {
+                    for (let i = 0; i < line.stations.length; i++) {
+                        const s = line.stations[i];
+                        map.set(s.id, s.name_ja);
+                    }
+                }
+            }
+            return map;
+        }, [railwayData]);
+        ```
+    *   Replace `Object.values(railwayData).forEach...` with:
+        ```typescript
+        const startName = stationNameMap.get(trip.fromId) || '';
+        const endName = stationNameMap.get(trip.toId) || '';
+        ```
+
+4.  **Refactoring `WalkTripEditor.tsx`:**
+    *   Do the exact same `useMemo` mapping for `WalkTripEditor.tsx`.
+    *   Wait, in `WalkTripEditor.tsx` `onSave` it also needs `startCoords` and `endCoords`.
+    *   So let's build a `stationDataMap` that maps `id -> station`.
+
+    ```typescript
+    const stationDataMap = useMemo(() => {
+        const map = new Map<string, any>();
+        for (const key in railwayData) {
+            const line = railwayData[key];
+            if (line.stations) {
+                for (let i = 0; i < line.stations.length; i++) {
+                    map.set(line.stations[i].id, line.stations[i]);
+                }
+            }
+        }
+        return map;
+    }, [railwayData]);
+    ```
+
+    *   Then `let startName = stationDataMap.get(form.fromId)?.name_ja || t('walk.unknownStart', "未知起点");`
+
+5.  **Verify:** Check for syntax errors and build the app locally to ensure everything works correctly. Update `.jules/bolt.md` with the learning about O(N x M) rendering bottlenecks.

--- a/src/components/modals/WalkTripEditor.tsx
+++ b/src/components/modals/WalkTripEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { Edit2, X, AlertTriangle, Save, Trash2 } from 'lucide-react';
 import { useStore } from '../../store';
 import { useShallow } from 'zustand/react/shallow';
@@ -23,7 +23,23 @@ export const WalkTripEditor: React.FC = () => {
         user: state.user
     })));
 
-    const setForm = useStore(state => state.setTripForm);
+
+    // ⚡ Bolt: Replaced O(N*M) nested array lookups with O(1) Map lookup
+    // Optimization: Reduces WalkTripEditor render time by avoiding full iterations of railwayData
+    const stationDataMap = useMemo(() => {
+        const map = new Map<string, any>();
+        for (const key in railwayData) {
+            const line = railwayData[key];
+            if (line.stations) {
+                for (let i = 0; i < line.stations.length; i++) {
+                    map.set(line.stations[i].id, line.stations[i]);
+                }
+            }
+        }
+        return map;
+    }, [railwayData]);
+
+const setForm = useStore(state => state.setTripForm);
     const closeEditor = useStore(state => state.closeWalkTripEditor);
     const setTrips = useStore(state => state.setTrips);
     const { saveData } = useUserData();
@@ -82,12 +98,10 @@ export const WalkTripEditor: React.FC = () => {
             // Find coordinates for the Bezier curve
             let startCoords = null;
             let endCoords = null;
-            Object.values(railwayData).forEach(line => {
-                const s = line.stations.find(st => st.id === form.fromId);
-                if (s) startCoords = [s.lng, s.lat];
-                const e = line.stations.find(st => st.id === form.toId);
-                if (e) endCoords = [e.lng, e.lat];
-            });
+            const s = stationDataMap.get(form.fromId || '');
+            if (s) startCoords = [s.lng, s.lat];
+            const e = stationDataMap.get(form.toId || '');
+            if (e) endCoords = [e.lng, e.lat];
 
             if (startCoords && endCoords) {
                 walkPath = generateBezierPath(startCoords as [number, number], endCoords as [number, number]);
@@ -130,12 +144,10 @@ export const WalkTripEditor: React.FC = () => {
     // Resolving station names for read-only display
     let startName = t('walk.unknownStart', "未知起点");
     let endName = t('walk.unknownEnd', "未知终点");
-    Object.values(railwayData).forEach(line => {
-        const s = line.stations.find(st => st.id === form.fromId);
-        if (s) startName = s.name_ja;
-        const e = line.stations.find(st => st.id === form.toId);
-        if (e) endName = e.name_ja;
-    });
+    const startStation = stationDataMap.get(form.fromId || '');
+    if (startStation) startName = startStation.name_ja;
+    const endStation = stationDataMap.get(form.toId || '');
+    if (endStation) endName = endStation.name_ja;
 
     const isTree = form.walkType === 'tree';
 

--- a/src/pages/TripsPage.tsx
+++ b/src/pages/TripsPage.tsx
@@ -91,7 +91,23 @@ export const TripsPage: React.FC = () => {
     const { saveData } = useUserData();
     const { t } = useTranslation();
 
-    const fileInputRef = useRef<HTMLInputElement>(null);
+
+    // ⚡ Bolt: Replaced O(N*M) nested array lookups with O(1) Map lookup
+    // Optimization: Reduces TripsPage render time by avoiding full iterations of railwayData
+    const stationDataMap = useMemo(() => {
+        const map = new Map<string, any>();
+        for (const key in railwayData) {
+            const line = railwayData[key];
+            if (line.stations) {
+                for (let i = 0; i < line.stations.length; i++) {
+                    map.set(line.stations[i].id, line.stations[i]);
+                }
+            }
+        }
+        return map;
+    }, [railwayData]);
+
+const fileInputRef = useRef<HTMLInputElement>(null);
 
     const handleImportSuica = async (event: React.ChangeEvent<HTMLInputElement>) => {
         const file = event.target.files?.[0];
@@ -172,12 +188,10 @@ export const TripsPage: React.FC = () => {
                         if (isWalk) {
                             let startName = trip.fromId || '';
                             let endName = trip.toId || '';
-                            Object.values(railwayData).forEach(line => {
-                                const s = line.stations.find(st => st.id === trip.fromId);
-                                if (s) startName = s.name_ja;
-                                const e = line.stations.find(st => st.id === trip.toId);
-                                if (e) endName = e.name_ja;
-                            });
+                            const s = stationDataMap.get(trip.fromId);
+                            if (s) startName = s.name_ja;
+                            const e = stationDataMap.get(trip.toId);
+                            if (e) endName = e.name_ja;
 
                             const isTree = trip.walkType === 'tree';
                             const cls = {


### PR DESCRIPTION
💡 What: Implemented a memoized O(1) hash map lookup (`stationDataMap`) in `TripsPage.tsx` and `WalkTripEditor.tsx` to replace a nested iteration (`Object.values(railwayData).forEach()`) over the massive global object.
🎯 Why: Iterating over hundreds of lines and thousands of stations inside a render `.map()` loop creates an O(N x M) rendering bottleneck that drastically slows down rendering times as the user adds more trips.
📊 Impact: Reduces lookup time per trip element from O(M) to O(1), preventing main-thread blocking when rendering many trip rows.
🔬 Measurement: Can be verified by using the React DevTools Profiler to compare rendering times of `TripsPage` with 50+ trips before and after this change.

---
*PR created automatically by Jules for task [3003598709801686470](https://jules.google.com/task/3003598709801686470) started by @OsakaLOOP*