### PR TITLE
⚡ Bolt: Optimize calculateLatestStats by skipping redundant visual computation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-04-15 - [Avoid O(N log N) Sorting on Massive Geographical Collections]
 **Learning:** In spatial queries like `findNearbyStations` where we scan `railwayData` containing thousands of stations to find the top K nearest points, allocating all elements to an array and running `Array.prototype.sort()` results in massive temporary object allocation and $O(N \log N)$ execution time (taking ~8.5ms in benchmarks).
 **Action:** Replace full array sorts with a bounded Top-K array using a simple $O(K)$ insertion sort during the $O(N)$ iteration phase. This brings the time complexity effectively down to $O(N)$, speeding up operations by ~36x (taking ~0.24ms). Remember to apply a final sort if total elements found are less than $K$.
+
+## 2024-05-08 - [Avoid Redundant Visualization Processing in Stats Calculation]
+**Learning:** In `calculateLatestStats`, generating SVG paths, computing PCA for orientation, and calculating bounding boxes via `getRouteVisualData` for *all* trips just to get the `grandTotalDist` causes unnecessary CPU load and memory allocations.
+**Action:** Introduced a `skipVisuals` parameter to visualization-heavy helper functions. When calculating aggregate statistics over large arrays where only simple scalar values (like total distance) are needed, explicitly decouple or bypass the presentation-layer computations by passing `skipVisuals=true`.

--- a/src/core/tripCalculator.js
+++ b/src/core/tripCalculator.js
@@ -158,7 +158,7 @@ export const sliceGeoJsonPath = (feature, startLat, startLng, endLat, endLng) =>
 };
 
 // --- Shared Helper: Calculate Visualization Data ---
-export const getRouteVisualData = (segments, segmentGeometries, railwayData, geoData) => {
+export const getRouteVisualData = (segments, segmentGeometries, railwayData, geoData, skipVisuals = false) => {
     let totalDist = 0;
     const allCoords = [];
 
@@ -233,7 +233,7 @@ export const getRouteVisualData = (segments, segmentGeometries, railwayData, geo
         }
     });
 
-    if (allCoords.length === 0) return { totalDist, visualPaths: [] };
+    if (allCoords.length === 0 || skipVisuals) return { totalDist, visualPaths: [] };
 
     // PCA & Projection Logic
     let sumLat = 0, sumLng = 0, count = 0;
@@ -328,7 +328,7 @@ export const calculateLatestStats = (trips, segmentGeometries, railwayData, geoD
     const uniqueLines = new Set(allSegments.map(s => s.lineKey)).size;
 
     // Calc total distance using helper (aggregating cached or on-the-fly)
-    const { totalDist: grandTotalDist } = getRouteVisualData(allSegments, segmentGeometries, railwayData, geoData);
+    const { totalDist: grandTotalDist } = getRouteVisualData(allSegments, segmentGeometries, railwayData, geoData, true);
 
     // 2. Latest 5
     const latest = trips.slice(0, 5).map(t => {


### PR DESCRIPTION
💡 **What:** Added a `skipVisuals` parameter to `getRouteVisualData` (in `src/core/tripCalculator.js`) and passed `true` when computing the aggregate total distance in `calculateLatestStats`.
🎯 **Why:** `getRouteVisualData` performs heavy calculations (PCA, bounding boxes, SVG path string generation). When `calculateLatestStats` needs the grand total distance for all trips, it was running these visualization computations on *every single segment*, even though the visualization data (`visualPaths`) is only actually needed and rendered for the top 5 `latest` trips.
📊 **Impact:** Significantly reduces CPU overhead, loop iterations, string concatenations, and temporary memory allocations for users with many trips, improving overall dashboard loading and recalculation performance.
🔬 **Measurement:** Verify that `npm run lint` and `npx tsc --noEmit` pass, and that the top-level trip distance calculation accurately reflects the sum without UI degradation.

---
*PR created automatically by Jules for task [13839023043427465486](https://jules.google.com/task/13839023043427465486) started by @OsakaLOOP*