### PR TITLE
⚡ Bolt: [perf] bypass expensive visuals in stats aggregation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,6 @@
 ## 2024-04-15 - [Avoid O(N log N) Sorting on Massive Geographical Collections]
 **Learning:** In spatial queries like `findNearbyStations` where we scan `railwayData` containing thousands of stations to find the top K nearest points, allocating all elements to an array and running `Array.prototype.sort()` results in massive temporary object allocation and $O(N \log N)$ execution time (taking ~8.5ms in benchmarks).
 **Action:** Replace full array sorts with a bounded Top-K array using a simple $O(K)$ insertion sort during the $O(N)$ iteration phase. This brings the time complexity effectively down to $O(N)$, speeding up operations by ~36x (taking ~0.24ms). Remember to apply a final sort if total elements found are less than $K$.
+## 2024-05-09 - Bypass heavy path visuals for unseen aggregation
+**Learning:** Calculating total distances across all trips triggers expensive visual pipeline steps (like coordinate mapping, SVG path building, BBox bounding, and PCA projection) inside `getRouteVisualData` when extracting aggregate values in `calculateLatestStats`, needlessly burning CPU cycles since these visuals aren't actually shown on the dashboard.
+**Action:** Always decouple computation data paths from presentation paths. A simple `skipVisuals` parameter bypasses the heavy rendering logic while safely maintaining the accuracy of data calculations.

--- a/src/core/tripCalculator.js
+++ b/src/core/tripCalculator.js
@@ -158,7 +158,7 @@ export const sliceGeoJsonPath = (feature, startLat, startLng, endLat, endLng) =>
 };
 
 // --- Shared Helper: Calculate Visualization Data ---
-export const getRouteVisualData = (segments, segmentGeometries, railwayData, geoData) => {
+export const getRouteVisualData = (segments, segmentGeometries, railwayData, geoData, skipVisuals = false) => {
     let totalDist = 0;
     const allCoords = [];
 
@@ -215,11 +215,11 @@ export const getRouteVisualData = (segments, segmentGeometries, railwayData, geo
         if (geom && geom.coords) {
             if (geom.isMulti) {
                 geom.coords.forEach(c => {
-                    allCoords.push({ coords: c, color: geom.color || '#94a3b8' });
+                    if (!skipVisuals) allCoords.push({ coords: c, color: geom.color || '#94a3b8' });
                     if(turf) totalDist += turf.length(turf.lineString(c.map(p => [p[1], p[0]])));
                 });
             } else {
-                allCoords.push({ coords: geom.coords, color: geom.color || '#94a3b8' });
+                if (!skipVisuals) allCoords.push({ coords: geom.coords, color: geom.color || '#94a3b8' });
                 if(turf) totalDist += turf.length(turf.lineString(geom.coords.map(p => [p[1], p[0]])));
             }
         } else {
@@ -233,7 +233,7 @@ export const getRouteVisualData = (segments, segmentGeometries, railwayData, geo
         }
     });
 
-    if (allCoords.length === 0) return { totalDist, visualPaths: [] };
+    if (allCoords.length === 0 || skipVisuals) return { totalDist, visualPaths: [] };
 
     // PCA & Projection Logic
     let sumLat = 0, sumLng = 0, count = 0;
@@ -328,7 +328,7 @@ export const calculateLatestStats = (trips, segmentGeometries, railwayData, geoD
     const uniqueLines = new Set(allSegments.map(s => s.lineKey)).size;
 
     // Calc total distance using helper (aggregating cached or on-the-fly)
-    const { totalDist: grandTotalDist } = getRouteVisualData(allSegments, segmentGeometries, railwayData, geoData);
+    const { totalDist: grandTotalDist } = getRouteVisualData(allSegments, segmentGeometries, railwayData, geoData, true);
 
     // 2. Latest 5
     const latest = trips.slice(0, 5).map(t => {


### PR DESCRIPTION
💡 What: Added a `skipVisuals` parameter to `getRouteVisualData` and updated `calculateLatestStats` to utilize it. This bypasses the array allocation, PCA calculations, and SVG generation when looping through all historical trip segments just to sum the total distance.
🎯 Why: In `src/core/tripCalculator.js`, extracting `grandTotalDist` processes every segment over all a user's trips. Running geographic PCA and path generations for thousands of hidden objects consumed unnecessary CPU and GC pressure since these elements were never rendered.
📊 Impact: Considerably faster computation of `grandTotalDist`, fewer memory allocations for unused arrays, dropping iteration complexity when calculating the user dashboard stats.
🔬 Measurement: Compare application rendering performance or measure function execution time of `calculateLatestStats` when a user has a large number of saved trips.

---
*PR created automatically by Jules for task [13774249465969495993](https://jules.google.com/task/13774249465969495993) started by @OsakaLOOP*