### PR TITLE
⚡ Bolt: Optimize polyline distance calculation to reduce GC pressure

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-04-15 - [Avoid O(N log N) Sorting on Massive Geographical Collections]
 **Learning:** In spatial queries like `findNearbyStations` where we scan `railwayData` containing thousands of stations to find the top K nearest points, allocating all elements to an array and running `Array.prototype.sort()` results in massive temporary object allocation and $O(N \log N)$ execution time (taking ~8.5ms in benchmarks).
 **Action:** Replace full array sorts with a bounded Top-K array using a simple $O(K)$ insertion sort during the $O(N)$ iteration phase. This brings the time complexity effectively down to $O(N)$, speeding up operations by ~36x (taking ~0.24ms). Remember to apply a final sort if total elements found are less than $K$.
+
+## 2024-05-31 - [Avoid Temporary GeoJSON Allocation in Loops]
+**Learning:** Using `turf.length(turf.lineString(coords))` inside loops (e.g. `StatsPage` calculations or drawing polyline segments) creates massive temporary object allocations (GeoJSON features) and puts unnecessary pressure on garbage collection.
+**Action:** Use an O(N) custom calculator `calcPolylineDist(coords)` that calls Haversine `calcDist` over `[lat, lng]` coordinate pairs sequentially instead. This drastically decreases memory allocations during batch stats processing.

--- a/src/core/tripCalculator.js
+++ b/src/core/tripCalculator.js
@@ -13,6 +13,16 @@ export const calcDist = (lat1, lon1, lat2, lon2) => {
   return R * c;
 };
 
+// 计算 [lat, lng] 数组的折线总距离，避免 turf.lineString 分配临时对象带来的 GC 压力
+export const calcPolylineDist = (coords) => {
+  if (!coords || coords.length < 2) return 0;
+  let dist = 0;
+  for (let i = 0; i < coords.length - 1; i++) {
+    dist += calcDist(coords[i][0], coords[i][1], coords[i + 1][0], coords[i + 1][1]);
+  }
+  return dist;
+};
+
 // [New] 路径缝合算法: 将乱序的 MultiLineString 缝合成连续的 LineString
 export const stitchRoutes = (turf, multiCoords, startPt) => {
   let pool = multiCoords.map((coords, i) => {
@@ -216,11 +226,11 @@ export const getRouteVisualData = (segments, segmentGeometries, railwayData, geo
             if (geom.isMulti) {
                 geom.coords.forEach(c => {
                     allCoords.push({ coords: c, color: geom.color || '#94a3b8' });
-                    if(turf) totalDist += turf.length(turf.lineString(c.map(p => [p[1], p[0]])));
+                    totalDist += calcPolylineDist(c);
                 });
             } else {
                 allCoords.push({ coords: geom.coords, color: geom.color || '#94a3b8' });
-                if(turf) totalDist += turf.length(turf.lineString(geom.coords.map(p => [p[1], p[0]])));
+                totalDist += calcPolylineDist(geom.coords);
             }
         } else {
              // Fallback Distance Approx

--- a/src/pages/StatsPage.tsx
+++ b/src/pages/StatsPage.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { Github, Folder, TrendingUp, Move, MapPin, Map as MapIcon, Globe } from 'lucide-react';
 import { useStore } from '../store';
-import { calcDist } from '../core/tripCalculator';
+import { calcDist, calcPolylineDist } from '../core/tripCalculator';
 import * as turf from '@turf/turf';
 import { useShallow } from 'zustand/react/shallow';
 import { useUserData } from '../hooks/useUserData';
@@ -70,17 +70,17 @@ export const StatsPage: React.FC = () => {
                 uniqueLinesSet.add(seg.lineKey);
                 counts.set(seg.lineKey, (counts.get(seg.lineKey) || 0) + 1);
 
-                if (segmentGeometries && turf) {
+                if (segmentGeometries) {
                     const key = `${seg.lineKey}_${seg.fromId}_${seg.toId}`;
                     const geom = segmentGeometries.get(key);
                     if (geom && geom.coords) {
                         if (geom.isMulti) {
                             for (let k = 0; k < geom.coords.length; k++) {
                                 const c = geom.coords[k];
-                                _totalDist += turf.length(turf.lineString(c.map((p: any) => [p[1], p[0]])));
+                                _totalDist += calcPolylineDist(c);
                             }
                         } else {
-                            _totalDist += turf.length(turf.lineString(geom.coords.map((p: any) => [p[1], p[0]])));
+                            _totalDist += calcPolylineDist(geom.coords);
                         }
                     } else {
                         const line = railwayData[seg.lineKey];


### PR DESCRIPTION
⚡ **Bolt: Avoid Temporary GeoJSON Allocation in Loops**

💡 **What:**
Replaced `turf.length(turf.lineString(coords))` with an $O(N)$ custom calculator `calcPolylineDist(coords)` that calls Haversine `calcDist` over `[lat, lng]` coordinate pairs sequentially.

🎯 **Why:**
Using Turf inside map and nested loops inside `StatsPage.tsx` and `tripCalculator.js` caused massive overhead and pressure on garbage collection by repeatedly allocating and discarding temporary GeoJSON objects during batch statistical calculations.

📊 **Impact:**
Significantly reduces memory footprint during `useEffect` runs, leading to faster computations and less stutter/re-renders caused by heavy Garbage Collection passes.

🔬 **Measurement:**
Run `npm run build` and `npm run lint` and `npx tsc --noEmit` and check that tests pass correctly. Review the codebase-specific learning logged in `.jules/bolt.md`.

---
*PR created automatically by Jules for task [7147846058220378640](https://jules.google.com/task/7147846058220378640) started by @OsakaLOOP*