### PR TITLE
⚡ Bolt: Avoid massive temporary object allocations in Polyline distance calculation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-04-15 - [Avoid O(N log N) Sorting on Massive Geographical Collections]
 **Learning:** In spatial queries like `findNearbyStations` where we scan `railwayData` containing thousands of stations to find the top K nearest points, allocating all elements to an array and running `Array.prototype.sort()` results in massive temporary object allocation and $O(N \log N)$ execution time (taking ~8.5ms in benchmarks).
 **Action:** Replace full array sorts with a bounded Top-K array using a simple $O(K)$ insertion sort during the $O(N)$ iteration phase. This brings the time complexity effectively down to $O(N)$, speeding up operations by ~36x (taking ~0.24ms). Remember to apply a final sort if total elements found are less than $K$.
+
+## 2026-06-05 - [Avoid massive temporary object allocations in Polyline distance calculation]
+**Learning:** Found an opportunity to replace `turf.length(turf.lineString(...))` which was causing massive overhead from temporary object allocations when calculating path distances efficiently over `[lat, lng]` coordinate arrays. Turf's object instantiation can be extremely slow and memory hungry in loops.
+**Action:** Replace `turf.length(turf.lineString(...))` with a simple `O(N)` utility loop (e.g. `calcPolylineDist(coords)` that wraps the native Haversine `calcDist` formula) to manually accumulate segment distances. This bypasses the heavy GeoJSON wrapper creation completely.

--- a/src/core/tripCalculator.js
+++ b/src/core/tripCalculator.js
@@ -13,6 +13,16 @@ export const calcDist = (lat1, lon1, lat2, lon2) => {
   return R * c;
 };
 
+// 计算多段线的总长度
+export const calcPolylineDist = (coords) => {
+  if (!coords || coords.length < 2) return 0;
+  let dist = 0;
+  for (let i = 0; i < coords.length - 1; i++) {
+    dist += calcDist(coords[i][0], coords[i][1], coords[i+1][0], coords[i+1][1]);
+  }
+  return dist;
+};
+
 // [New] 路径缝合算法: 将乱序的 MultiLineString 缝合成连续的 LineString
 export const stitchRoutes = (turf, multiCoords, startPt) => {
   let pool = multiCoords.map((coords, i) => {
@@ -216,11 +226,11 @@ export const getRouteVisualData = (segments, segmentGeometries, railwayData, geo
             if (geom.isMulti) {
                 geom.coords.forEach(c => {
                     allCoords.push({ coords: c, color: geom.color || '#94a3b8' });
-                    if(turf) totalDist += turf.length(turf.lineString(c.map(p => [p[1], p[0]])));
+                    totalDist += calcPolylineDist(c);
                 });
             } else {
                 allCoords.push({ coords: geom.coords, color: geom.color || '#94a3b8' });
-                if(turf) totalDist += turf.length(turf.lineString(geom.coords.map(p => [p[1], p[0]])));
+                totalDist += calcPolylineDist(geom.coords);
             }
         } else {
              // Fallback Distance Approx

--- a/src/pages/StatsPage.tsx
+++ b/src/pages/StatsPage.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { Github, Folder, TrendingUp, Move, MapPin, Map as MapIcon, Globe } from 'lucide-react';
 import { useStore } from '../store';
-import { calcDist } from '../core/tripCalculator';
+import { calcDist, calcPolylineDist } from '../core/tripCalculator';
 import * as turf from '@turf/turf';
 import { useShallow } from 'zustand/react/shallow';
 import { useUserData } from '../hooks/useUserData';
@@ -77,10 +77,10 @@ export const StatsPage: React.FC = () => {
                         if (geom.isMulti) {
                             for (let k = 0; k < geom.coords.length; k++) {
                                 const c = geom.coords[k];
-                                _totalDist += turf.length(turf.lineString(c.map((p: any) => [p[1], p[0]])));
+                                _totalDist += calcPolylineDist(c);
                             }
                         } else {
-                            _totalDist += turf.length(turf.lineString(geom.coords.map((p: any) => [p[1], p[0]])));
+                            _totalDist += calcPolylineDist(geom.coords);
                         }
                     } else {
                         const line = railwayData[seg.lineKey];


### PR DESCRIPTION
⚡ Bolt: Avoid massive temporary object allocations in Polyline distance calculation

💡 What: Replaced `turf.length(turf.lineString(coords))` with a new utility loop `calcPolylineDist(coords)` in `tripCalculator.js` and `StatsPage.tsx`.
🎯 Why: `turf.length` with `turf.lineString` instantiates a heavy GeoJSON wrapper object, which is very slow and allocates a lot of memory, leading to major garbage collection overhead when done inside large presentation loops.
📊 Impact: Avoids allocating thousands of temporary GeoJSON objects, significantly improving loop execution speed and reducing garbage collection pressure.
🔬 Measurement: Verify by executing large route renderings or reloading the Stats Page to ensure calculations are correct and noticeably more responsive.

---
*PR created automatically by Jules for task [7140375625963030470](https://jules.google.com/task/7140375625963030470) started by @OsakaLOOP*