### PR TITLE
Rail graph: promote scenic viewpoint payloads

### DIFF
--- a/src/__tests__/mileage-events-runtime-adapter.test.ts
+++ b/src/__tests__/mileage-events-runtime-adapter.test.ts
@@ -234,6 +234,60 @@ describe("mileage events runtime adapter", () => {
     expect(projected).toHaveLength(1);
     expect(projected[0].timestampInference).toBe("linear");
   });
+
+  it("infers scenic viewpoint data on legacy GeoJSON axes without blocking projection", () => {
+    const lineKey = "app:test-scenic-line";
+    const railwayData: RailwayMap = {
+      [lineKey]: {
+        meta: {
+          company: "Test Railway",
+          region: "test",
+          type: "fixture",
+          logo: null,
+          color: "#0f766e",
+        },
+        stations: [
+          { id: "a", name_ja: "Alpha", lat: 35.0, lng: 139.0, transfers: [], distToNext: 5 },
+          { id: "b", name_ja: "Beta", lat: 35.0, lng: 139.05, transfers: [] },
+        ],
+      },
+    };
+    const lineContext = buildAppMileageLineContext(railwayData, lineKey)!;
+    const event = createMileageEventFromPlace({
+      lineContext,
+      place: { coordinates: [139.04, 35.01] },
+      title: "Window view",
+      kind: "scenic",
+    })!;
+
+    expect(event.payload?.viewpoint).toMatchObject({
+      facing: "left",
+      source: "inferred_from_geojson",
+      coordinates: [139.04, 35.01],
+    });
+    expect(event.payload?.targetCoordinates).toEqual([139.04, 35.01]);
+    expect(typeof event.payload?.viewpoint?.targetBearingDegrees).toBe("number");
+
+    const display = boundMileageEventForDisplay(event, railwayData);
+    expect(display?.bound.scenicVisibility?.status).not.toBe("unavailable");
+    expect(display?.bound.scenicVisibility?.facing).toBe("left");
+    expect(display?.bound.scenicVisibility?.confidence).toBeGreaterThan(0);
+
+    const stationEvent = createMileageEventFromStation({
+      lineContext,
+      stationId: "a",
+      title: "Default side view",
+      kind: "scenic",
+    })!;
+    expect(stationEvent.payload).not.toHaveProperty("targetCoordinates");
+    expect(stationEvent.payload?.viewpoint).toMatchObject({
+      facing: "right",
+      source: "inferred_from_geojson",
+    });
+    expect(stationEvent.payload?.viewpoint?.coordinates).toBeUndefined();
+    expect(stationEvent.payload?.viewpoint?.targetBearingDegrees).toBeGreaterThan(150);
+    expect(stationEvent.payload?.viewpoint?.targetBearingDegrees).toBeLessThan(210);
+  });
 });
 
 function loadWillerRailwayData(): RailwayMap {

--- a/src/__tests__/rail-graph-trip-planner.test.ts
+++ b/src/__tests__/rail-graph-trip-planner.test.ts
@@ -42,6 +42,15 @@ describe("rail-graph trip planner", () => {
       "note",
     ]));
     expect(result.trip.segments[0].events.filter((event) => event.type === "stop")).toHaveLength(2);
+    const scenic = result.trip.segments[0].events.find((event) => event.type === "scenic");
+    expect(scenic).toMatchObject({
+      type: "scenic",
+      viewSide: "right",
+      viewpoint: {
+        facing: "right",
+        source: "system_anchor",
+      },
+    });
     expect(result.trip.segments[0].mileageProfile).toMatchObject({
       systemRef: "manual:system:test",
       lineRef: "manual:line:test",

--- a/src/rail-graph-v1/mileage-event.types.ts
+++ b/src/rail-graph-v1/mileage-event.types.ts
@@ -17,6 +17,51 @@ export type MileageUserEventVisibility = "private" | "shared" | "public";
 
 export type MileageTimestampInference = "timeline" | "linear" | "unknown";
 
+export type ScenicFacing = "left" | "right" | "front" | "back";
+export type ScenicViewpointSource =
+  | "system_anchor"
+  | "user_explicit"
+  | "inferred_from_route"
+  | "inferred_from_geojson";
+export type ScenicVisibilityStatus =
+  | "visible"
+  | "opposite_side"
+  | "angle_mismatch"
+  | "unknown"
+  | "unavailable";
+
+export interface ScenicVisibilityConstraint {
+  targetBearingDegrees?: number;
+  visibleBearingRangeDegrees?: [number, number];
+  angleToleranceDegrees?: number;
+  distanceMeters?: number;
+}
+
+export interface ScenicViewpointPayload {
+  facing: ScenicFacing;
+  coordinates?: GeoJSONPosition;
+  targetBearingDegrees?: number;
+  visibleBearingRangeDegrees?: [number, number];
+  constraint?: ScenicVisibilityConstraint;
+  source: ScenicViewpointSource;
+  confidence?: number;
+  diagnostics?: Diagnostic[];
+}
+
+export interface ScenicVisibilityResolution {
+  status: ScenicVisibilityStatus;
+  facing?: ScenicFacing;
+  runDirectionBearingDegrees?: number;
+  targetBearingDegrees?: number;
+  relativeBearingDegrees?: number;
+  confidence: number;
+  diagnostics: Diagnostic[];
+}
+
+export interface UserEventV2Payload extends Record<string, unknown> {
+  viewpoint?: ScenicViewpointPayload;
+}
+
 export interface MileageRef {
   systemRef: EntityRef;
   lineRef?: EntityRef;
@@ -41,7 +86,7 @@ export interface UserEventV2 {
   range?: MileageRange;
   visibility: MileageUserEventVisibility;
   tags?: string[];
-  payload?: Record<string, unknown>;
+  payload?: UserEventV2Payload;
   createdAt?: ISODateTime;
   updatedAt?: ISODateTime;
 }
@@ -57,6 +102,7 @@ export interface BoundMileageEvent {
   edgeRef?: EntityRef;
   coordinates?: GeoJSONPosition;
   diagnostics: Diagnostic[];
+  scenicVisibility?: ScenicVisibilityResolution;
 }
 
 export interface MileageEdgeSpan {

--- a/src/rail-graph-v1/mileage-events.ts
+++ b/src/rail-graph-v1/mileage-events.ts
@@ -17,6 +17,9 @@ import type {
   MileageTimeQuery,
   MileageTimelinePoint,
   ResolvedMileagePlace,
+  ScenicFacing,
+  ScenicViewpointPayload,
+  ScenicVisibilityResolution,
   UserEventV2,
 } from "./mileage-event.types";
 import type { EntityRef } from "./primitives";
@@ -119,6 +122,12 @@ export function projectEventToRunPath(
   const nearest = nearestPathEntity(eventStart, runPath, context);
   const time = interpolateTimestamp(eventStart, context);
 
+  const scenicVisibility = resolveScenicVisibility(event, {
+    context,
+    edgeRef: nearest.edgeRef,
+    eventCoordinates: nearest.coordinates,
+  });
+
   return {
     event,
     distanceMetersFromRunStart: Math.max(0, distanceMetersFromRunStart),
@@ -129,6 +138,7 @@ export function projectEventToRunPath(
     timestamp: time.timestamp,
     timestampInference: time.inference,
     diagnostics: time.diagnostics,
+    ...(scenicVisibility ? { scenicVisibility } : {}),
   };
 }
 
@@ -254,11 +264,124 @@ export function validateUserEventV2(value: unknown): UserEventV2 {
   }
   return {
     ...event,
+    payload: normalizeUserEventPayload(event),
     mileage: {
       ...event.mileage,
       distanceMeters: Math.max(0, event.mileage.distanceMeters),
     },
     range: event.range ? normalizeMileageRange(event.range.startMeters, event.range.endMeters) : undefined,
+  };
+}
+
+export function inferScenicViewpointPayload(args: {
+  context: MileageProjectionContext;
+  distanceMeters: number;
+  targetCoordinates?: GeoJSONPosition;
+  explicitFacing?: ScenicFacing;
+  source?: ScenicViewpointPayload["source"];
+}): ScenicViewpointPayload {
+  const nearest = nearestPathEntity(args.distanceMeters, contextToRunPath(args.context), args.context);
+  const runBearing = nearest.edgeRef ? edgeBearingDegrees(args.context.edgeMileage[nearest.edgeRef]) : undefined;
+  const measuredTargetBearing = args.targetCoordinates && nearest.coordinates
+    ? bearingDegrees(nearest.coordinates, args.targetCoordinates)
+    : undefined;
+  const facing = args.explicitFacing ?? facingFromBearings(runBearing, measuredTargetBearing) ?? "right";
+  const targetBearing = measuredTargetBearing ?? bearingFromFacing(runBearing, facing);
+  const confidence = typeof runBearing === "number" && typeof measuredTargetBearing === "number"
+    ? 0.75
+    : typeof runBearing === "number"
+      ? 0.45
+      : 0.25;
+  const diagnostics: Diagnostic[] = [];
+  if (typeof runBearing !== "number") {
+    diagnostics.push(diagnostic("warn", "SCENIC_RUN_BEARING_UNKNOWN", "Route bearing could not be inferred for scenic viewpoint."));
+  }
+  if (typeof targetBearing !== "number") {
+    diagnostics.push(diagnostic("info", "SCENIC_TARGET_BEARING_INFERRED", "Scenic target bearing is provisional until the user adjusts it."));
+  }
+  return {
+    facing,
+    ...(args.targetCoordinates ? { coordinates: args.targetCoordinates } : {}),
+    ...(typeof targetBearing === "number" ? {
+      targetBearingDegrees: targetBearing,
+      visibleBearingRangeDegrees: bearingRange(targetBearing, 30),
+      constraint: {
+        targetBearingDegrees: targetBearing,
+        visibleBearingRangeDegrees: bearingRange(targetBearing, 30),
+        angleToleranceDegrees: 30,
+      },
+    } : {}),
+    source: args.source ?? "inferred_from_route",
+    confidence,
+    diagnostics,
+  };
+}
+
+export function resolveScenicVisibility(
+  event: UserEventV2,
+  args: {
+    context: MileageProjectionContext;
+    edgeRef?: EntityRef;
+    eventCoordinates?: GeoJSONPosition;
+  },
+): ScenicVisibilityResolution | null {
+  const viewpoint = event.payload?.viewpoint;
+  if (event.kind !== "scenic" && !viewpoint) return null;
+  if (!viewpoint?.facing) {
+    return {
+      status: "unknown",
+      confidence: 0,
+      diagnostics: [diagnostic("warn", "SCENIC_VIEWPOINT_MISSING", "Scenic event has no viewpoint payload.")],
+    };
+  }
+
+  const runBearing = args.edgeRef ? edgeBearingDegrees(args.context.edgeMileage[args.edgeRef]) : undefined;
+  const targetBearing = viewpoint.targetBearingDegrees
+    ?? (viewpoint.coordinates && args.eventCoordinates ? bearingDegrees(args.eventCoordinates, viewpoint.coordinates) : undefined);
+  const relativeBearing = typeof runBearing === "number" && typeof targetBearing === "number"
+    ? normalizeSignedBearing(targetBearing - runBearing)
+    : undefined;
+  const expectedFacing = typeof relativeBearing === "number" ? facingFromRelativeBearing(relativeBearing) : undefined;
+  const diagnostics: Diagnostic[] = [...(viewpoint.diagnostics ?? [])];
+
+  if (typeof runBearing !== "number") {
+    diagnostics.push(diagnostic("warn", "SCENIC_RUN_BEARING_UNKNOWN", "Route bearing is unavailable for scenic visibility."));
+    return {
+      status: "unknown",
+      facing: viewpoint.facing,
+      targetBearingDegrees: targetBearing,
+      confidence: Math.min(viewpoint.confidence ?? 0.5, 0.4),
+      diagnostics,
+    };
+  }
+  if (typeof targetBearing !== "number" || typeof relativeBearing !== "number" || !expectedFacing) {
+    diagnostics.push(diagnostic("info", "SCENIC_TARGET_BEARING_UNKNOWN", "Scenic target bearing is unavailable."));
+    return {
+      status: "unknown",
+      facing: viewpoint.facing,
+      runDirectionBearingDegrees: runBearing,
+      confidence: Math.min(viewpoint.confidence ?? 0.5, 0.5),
+      diagnostics,
+    };
+  }
+
+  const angleTolerance = viewpoint.constraint?.angleToleranceDegrees ?? 45;
+  const status = expectedFacing !== viewpoint.facing
+    ? oppositeFacing(expectedFacing, viewpoint.facing)
+      ? "opposite_side"
+      : "angle_mismatch"
+    : Math.abs(relativeBearingForFacing(viewpoint.facing, relativeBearing)) > angleTolerance
+      ? "angle_mismatch"
+      : "visible";
+
+  return {
+    status,
+    facing: viewpoint.facing,
+    runDirectionBearingDegrees: runBearing,
+    targetBearingDegrees: targetBearing,
+    relativeBearingDegrees: relativeBearing,
+    confidence: viewpoint.confidence ?? 0.75,
+    diagnostics,
   };
 }
 
@@ -590,6 +713,93 @@ function projectPointToPolyline(point: GeoJSONPosition, span: MileageEdgeSpan): 
     walked += segLen;
   }
   return best;
+}
+
+function normalizeUserEventPayload(event: UserEventV2): UserEventV2["payload"] {
+  const payload = event.payload;
+  if (!payload || typeof payload !== "object") return payload;
+  const viewpoint = payload.viewpoint;
+  if (event.kind !== "scenic" || !viewpoint || typeof viewpoint !== "object") return payload;
+  const candidate = viewpoint as ScenicViewpointPayload;
+  if (!candidate.facing) return payload;
+  return {
+    ...payload,
+    viewpoint: {
+      ...candidate,
+      source: candidate.source ?? "user_explicit",
+      confidence: typeof candidate.confidence === "number" ? Math.max(0, Math.min(1, candidate.confidence)) : undefined,
+      diagnostics: candidate.diagnostics ?? [],
+    },
+  };
+}
+
+function edgeBearingDegrees(span: MileageEdgeSpan | undefined): number | undefined {
+  const coords = span?.coordinates;
+  if (!coords || coords.length < 2) return undefined;
+  return bearingDegrees(coords[0], coords[coords.length - 1]);
+}
+
+function bearingDegrees(from: GeoJSONPosition, to: GeoJSONPosition): number {
+  const fromLat = toRadians(from[1]);
+  const toLat = toRadians(to[1]);
+  const deltaLng = toRadians(to[0] - from[0]);
+  const y = Math.sin(deltaLng) * Math.cos(toLat);
+  const x = Math.cos(fromLat) * Math.sin(toLat)
+    - Math.sin(fromLat) * Math.cos(toLat) * Math.cos(deltaLng);
+  return normalizeBearing(Math.atan2(y, x) * 180 / Math.PI);
+}
+
+function normalizeBearing(value: number): number {
+  return ((value % 360) + 360) % 360;
+}
+
+function normalizeSignedBearing(value: number): number {
+  const normalized = normalizeBearing(value);
+  return normalized > 180 ? normalized - 360 : normalized;
+}
+
+function bearingRange(center: number, halfWidth: number): [number, number] {
+  return [normalizeBearing(center - halfWidth), normalizeBearing(center + halfWidth)];
+}
+
+function facingFromBearings(runBearing?: number, targetBearing?: number): ScenicFacing | undefined {
+  if (typeof runBearing !== "number" || typeof targetBearing !== "number") return undefined;
+  return facingFromRelativeBearing(normalizeSignedBearing(targetBearing - runBearing));
+}
+
+function bearingFromFacing(runBearing: number | undefined, facing: ScenicFacing): number | undefined {
+  if (typeof runBearing !== "number") return undefined;
+  switch (facing) {
+    case "front":
+      return normalizeBearing(runBearing);
+    case "right":
+      return normalizeBearing(runBearing + 90);
+    case "back":
+      return normalizeBearing(runBearing + 180);
+    case "left":
+      return normalizeBearing(runBearing - 90);
+  }
+}
+
+function facingFromRelativeBearing(relativeBearing: number): ScenicFacing {
+  const absolute = Math.abs(relativeBearing);
+  if (absolute <= 45) return "front";
+  if (absolute >= 135) return "back";
+  return relativeBearing > 0 ? "right" : "left";
+}
+
+function oppositeFacing(expected: ScenicFacing, actual: ScenicFacing): boolean {
+  return (expected === "left" && actual === "right")
+    || (expected === "right" && actual === "left")
+    || (expected === "front" && actual === "back")
+    || (expected === "back" && actual === "front");
+}
+
+function relativeBearingForFacing(facing: ScenicFacing, relativeBearing: number): number {
+  if (facing === "front") return relativeBearing;
+  if (facing === "back") return Math.abs(relativeBearing) - 180;
+  if (facing === "right") return relativeBearing - 90;
+  return relativeBearing + 90;
 }
 
 function interpolateOnSpan(span: MileageEdgeSpan, measure: number): GeoJSONPosition | undefined {

--- a/src/rail-graph-v1/trip-planner.ts
+++ b/src/rail-graph-v1/trip-planner.ts
@@ -5,6 +5,7 @@
 import type { DeployedSystem, PathPreset, PlanTripResult, TripPlanRequest } from "./deployment.types";
 import type { RunEvent } from "./event.types";
 import type { RunContext, SystemContext } from "./graph.types";
+import type { ScenicFacing, ScenicViewpointPayload } from "./mileage-event.types";
 import type { EntityRef } from "./primitives";
 import type { RunSpec } from "./runtime.types";
 import type { ServicePattern, ServiceTraceEntry } from "./service-template.types";
@@ -539,6 +540,7 @@ function tripEventFromRunEvent(system: SystemContext, event: RunEvent): TripEven
         label: "Scenic view",
         timestamp: event.timestamp,
         viewSide: vehicleViewSide(event),
+        viewpoint: scenicViewpointFromRunEvent(event),
       }];
     case "user_defined":
       return [{
@@ -722,7 +724,45 @@ function mileageProfileFromResolvedPath(args: {
   };
 }
 
-function vehicleViewSide(event: RunEvent): "left" | "right" | "front" | "back" | undefined {
+function vehicleViewSide(event: RunEvent): ScenicFacing | undefined {
   const side = (event.payload?.vehicleView as { side?: unknown } | undefined)?.side;
   return side === "left" || side === "right" || side === "front" || side === "back" ? side : undefined;
+}
+
+function scenicViewpointFromRunEvent(event: RunEvent): ScenicViewpointPayload | undefined {
+  const vehicleView = event.payload?.vehicleView as {
+    side?: unknown;
+    relativeBearingDegrees?: unknown;
+    runDirectionBearingDegrees?: unknown;
+  } | undefined;
+  const facing = vehicleViewSide(event);
+  if (!facing) return undefined;
+  const runBearing = typeof vehicleView?.runDirectionBearingDegrees === "number"
+    ? vehicleView.runDirectionBearingDegrees
+    : undefined;
+  const relativeBearing = typeof vehicleView?.relativeBearingDegrees === "number"
+    ? vehicleView.relativeBearingDegrees
+    : undefined;
+  const targetBearing = typeof runBearing === "number" && typeof relativeBearing === "number"
+    ? normalizeBearing(runBearing + relativeBearing)
+    : undefined;
+  return {
+    facing,
+    ...(typeof targetBearing === "number" ? {
+      targetBearingDegrees: targetBearing,
+      visibleBearingRangeDegrees: [normalizeBearing(targetBearing - 45), normalizeBearing(targetBearing + 45)] as [number, number],
+      constraint: {
+        targetBearingDegrees: targetBearing,
+        visibleBearingRangeDegrees: [normalizeBearing(targetBearing - 45), normalizeBearing(targetBearing + 45)] as [number, number],
+        angleToleranceDegrees: 45,
+      },
+    } : {}),
+    source: "system_anchor",
+    confidence: typeof targetBearing === "number" ? 0.9 : 0.6,
+    diagnostics: [],
+  };
+}
+
+function normalizeBearing(value: number): number {
+  return ((value % 360) + 360) % 360;
 }

--- a/src/rail-graph-v1/user-facing.types.ts
+++ b/src/rail-graph-v1/user-facing.types.ts
@@ -9,6 +9,8 @@ import type {
   MileageEdgeSpan,
   MileageStationPoint,
   MileageTimelinePoint,
+  ScenicFacing,
+  ScenicViewpointPayload,
 } from "./mileage-event.types";
 import type { DirectionLabel, EntityRef } from "./primitives";
 import type { ResolvedGeoJsonPath, RunPath } from "./runtime.types";
@@ -163,7 +165,8 @@ export interface TripScenicEvent {
   title?: string;
   description?: string;
   imageUrls?: string[];
-  viewSide?: "left" | "right" | "front" | "back";
+  viewSide?: ScenicFacing;
+  viewpoint?: ScenicViewpointPayload;
 }
 
 export interface TripNoteEvent {

--- a/src/utils/mileageUserEvents.ts
+++ b/src/utils/mileageUserEvents.ts
@@ -11,6 +11,7 @@ import type { EntityRef } from "../rail-graph-v1/primitives";
 import type { TripResult as RailGraphTripResult, TripResultSegment } from "../rail-graph-v1/user-facing.types";
 import {
   compareBoundMileageEvents,
+  inferScenicViewpointPayload,
   projectEventToRunPath,
   queryEventsByMileage as queryCoreEventsByMileage,
   queryEventsByTime as queryCoreEventsByTime,
@@ -272,6 +273,7 @@ export function createMileageEventFromCoordinates(args: {
     draft: args,
     payload: {
       createdFrom: "map_point",
+      targetCoordinates: args.coordinates,
       projectedCoordinates: resolved.coordinates,
       projectionMethod: resolved.method,
       projectionDiagnostics: resolved.diagnostics,
@@ -302,6 +304,7 @@ export function createMileageEventFromPlace(args: {
       createdFrom,
       projectionMethod: resolved.method,
       projectionDiagnostics: resolved.diagnostics,
+      ...(args.place.coordinates ? { targetCoordinates: args.place.coordinates } : {}),
       ...(resolved.coordinates ? { projectedCoordinates: resolved.coordinates } : {}),
       ...(resolved.stationRef ? { stationRef: resolved.stationRef, stationId: stationIdFromRef(resolved.stationRef) } : {}),
       ...(resolved.edgeRef ? { edgeRef: resolved.edgeRef } : {}),
@@ -909,10 +912,28 @@ function createMileageEventAtResolvedDistance(args: {
   const now = new Date().toISOString();
   const mediaUrl = args.draft.mediaUrl?.trim();
   const tripId = args.draft.tripId;
+  const kind = args.draft.kind ?? "user_note";
+  const basePayload: Record<string, unknown> = {
+    ...(args.payload ?? {}),
+    lineKey: args.lineContext.lineKey,
+    contextSource: args.lineContext.source ?? "legacy_app",
+    ...(mediaUrl ? { mediaUrl } : {}),
+    ...(tripId !== undefined && tripId !== "" ? { tripId } : {}),
+  };
+  const viewpoint = kind === "scenic"
+    ? inferScenicViewpointPayload({
+      context: args.lineContext.context,
+      distanceMeters: args.distanceMeters,
+      targetCoordinates: Array.isArray(basePayload.targetCoordinates)
+        ? basePayload.targetCoordinates as [number, number]
+        : undefined,
+      source: args.lineContext.source === "rail_graph_runtime" ? "inferred_from_route" : "inferred_from_geojson",
+    })
+    : undefined;
   return {
     schemaVersion: "mileage-user-event-v1",
     id: args.id,
-    kind: args.draft.kind ?? "user_note",
+    kind,
     title: cleanTitle(args.draft.title),
     body: cleanOptional(args.draft.body),
     mileage: {
@@ -925,11 +946,8 @@ function createMileageEventAtResolvedDistance(args: {
     visibility: args.draft.visibility ?? "private",
     tags: normalizeTags(args.draft.tags),
     payload: {
-      ...(args.payload ?? {}),
-      lineKey: args.lineContext.lineKey,
-      contextSource: args.lineContext.source ?? "legacy_app",
-      ...(mediaUrl ? { mediaUrl } : {}),
-      ...(tripId !== undefined && tripId !== "" ? { tripId } : {}),
+      ...basePayload,
+      ...(viewpoint ? { viewpoint } : {}),
     },
     createdAt: now,
     updatedAt: now,


### PR DESCRIPTION
Summary:
- Adds ScenicViewpointPayload, facing, angle constraints, and scenic visibility resolution.
- Projects system and user scenic events through the same viewpoint contract.
- Preserves legacy GeoJSON as a first-class path by inferring scenic viewpoint data when possible.

Stack: PR 2 of 5. Base is PR 1.
Validation:
- git diff --check HEAD~5..HEAD
- npx tsc --noEmit
- npx vitest run src/__tests__/rail-graph-selection.test.ts src/__tests__/mileage-events-runtime-adapter.test.ts src/__tests__/rail-graph-trip-planner.test.ts src/__tests__/scenic-visibility-layer.test.ts
- npx vite build
- npm --prefix blog run build

Note: pre-commit could not be run locally because this checkout has no .pre-commit-config, no .git/hooks/pre-commit, and no pre-commit executable.