### PR TITLE
Rail graph: render scenic visibility on map

### DIFF
--- a/src/__tests__/scenic-visibility-layer.test.ts
+++ b/src/__tests__/scenic-visibility-layer.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @vitest-environment jsdom
+ */
+import * as L from "leaflet";
+import { describe, expect, it } from "vitest";
+import {
+  createScenicVisibilityLayer,
+  updateScenicVisibilityLayer,
+  type ScenicVisibilityMapItem,
+} from "../components/map/scenicVisibilityLayer";
+
+function item(overrides: Partial<ScenicVisibilityMapItem> = {}): ScenicVisibilityMapItem {
+  return {
+    id: "scenic:test",
+    lat: 35.68,
+    lng: 139.76,
+    color: "#0ea5e9",
+    title: "Scenic test",
+    status: "visible",
+    bearingDegrees: 90,
+    angleToleranceDegrees: 30,
+    selected: false,
+    dimmed: false,
+    ...overrides,
+  };
+}
+
+describe("scenic visibility Leaflet layer", () => {
+  it("creates a first-class fan, ray, and origin marker for scenic visibility", () => {
+    const layer = createScenicVisibilityLayer(item()) as L.LayerGroup;
+    const layers = layer.getLayers();
+
+    expect(layers).toHaveLength(3);
+    expect(layers[0]).toBeInstanceOf(L.Polygon);
+    expect(layers[1]).toBeInstanceOf(L.Polyline);
+    expect(layers[2]).toBeInstanceOf(L.CircleMarker);
+    expect((layers[0] as L.Polygon).options.interactive).toBe(false);
+    expect((layers[1] as L.Polyline).options.pane).toBe("mileageEventsPane");
+  });
+
+  it("updates geometry and status style without recreating the layer group", () => {
+    const layer = createScenicVisibilityLayer(item()) as L.LayerGroup;
+    const [, rayBefore] = layer.getLayers();
+
+    updateScenicVisibilityLayer(layer, item({
+      lat: 35.7,
+      lng: 139.8,
+      status: "angle_mismatch",
+      bearingDegrees: 135,
+      angleToleranceDegrees: 45,
+      selected: true,
+    }));
+
+    const [, rayAfter, originAfter] = layer.getLayers();
+    expect(rayAfter).toBe(rayBefore);
+    expect((rayAfter as L.Polyline).options.dashArray).toBe("6 5");
+    expect((rayAfter as L.Polyline).options.weight).toBe(3);
+    expect((originAfter as L.CircleMarker).getLatLng().lat).toBeCloseTo(35.7);
+    expect((originAfter as L.CircleMarker).getLatLng().lng).toBeCloseTo(139.8);
+  });
+});

--- a/src/components/map/MapContainer.tsx
+++ b/src/components/map/MapContainer.tsx
@@ -14,6 +14,11 @@ import { cachedTileLayer } from "../../utils/CachedTileLayer";
 import { useShallow } from "zustand/react/shallow";
 import toast from "react-hot-toast";
 import { useAppRouteState } from "../../hooks/useAppRouteState";
+import {
+  createScenicVisibilityLayer,
+  updateScenicVisibilityLayer,
+  type ScenicVisibilityMapItem,
+} from "./scenicVisibilityLayer";
 import { boundMileageEventsForRichDisplay } from "../../utils/mileageUserEvents";
 import { tripToProductSegments } from "../../utils/tripProductProjection";
 import {
@@ -30,6 +35,7 @@ import {
 } from "../../utils/mileageEventUiBridge";
 import {
   activeAxisFromRailGraphSelection,
+  isEventSelection,
   railGraphSelectionSourceFromProjection,
   selectionFromActiveAxis,
   selectionFromMileageEventSelect,
@@ -75,6 +81,7 @@ export const MapContainer: React.FC<Props> = ({
   const visitedStationsRef = useRef<Set<string>>(new Set());
   const routeLayer = useRef<L.LayerGroup | null>(null);
   const mileageEventsLayer = useRef<L.LayerGroup | null>(null);
+  const scenicVisibilityLayer = useRef<L.LayerGroup | null>(null);
   const railLayerRef = useRef<L.TileLayer | null>(null);
   const rubberBandLayerRef = useRef<L.LayerGroup | null>(null);
   const pendingFlyToLocationRef = useRef<FlyToLocationDetail | null>(null);
@@ -244,7 +251,7 @@ export const MapContainer: React.FC<Props> = ({
       return;
     }
     setActiveMileageAxis(activeAxisFromRailGraphSelection(activeRailGraphSelection));
-    setSelectedMileageEventId(activeRailGraphSelection.kind === "event" ? activeRailGraphSelection.eventId ?? null : null);
+    setSelectedMileageEventId(isEventSelection(activeRailGraphSelection) ? activeRailGraphSelection.eventId ?? null : null);
   }, [activeRailGraphSelection]);
 
   useEffect(() => {
@@ -538,7 +545,7 @@ export const MapContainer: React.FC<Props> = ({
       .layers(
         { "标准 (light)": light, "暗色 (Dark)": dark },
         { "详细配线图 (OpenRailwayMap)": rail },
-        { position: "topright" },
+        { position: "topleft" },
       )
       .addTo(map);
 
@@ -587,6 +594,7 @@ export const MapContainer: React.FC<Props> = ({
     baseStationsLayer.current = L.layerGroup().addTo(map);
     routeLayer.current = L.layerGroup().addTo(map);
     pinsLayer.current = L.layerGroup().addTo(map);
+    scenicVisibilityLayer.current = L.layerGroup().addTo(map);
     mileageEventsLayer.current = L.layerGroup().addTo(map);
     rubberBandLayerRef.current = L.layerGroup().addTo(map);
 
@@ -1859,6 +1867,8 @@ export const MapContainer: React.FC<Props> = ({
       selectionDetails: MileageEventSelectDetail[];
       lineKeys: Set<string>;
       sourceKinds: Set<"rail_graph" | "legacy">;
+      scenic: boolean;
+      scenicStatuses: Set<string>;
       selected: boolean;
       activeLine: boolean;
       dimmed: boolean;
@@ -1903,6 +1913,8 @@ export const MapContainer: React.FC<Props> = ({
       const lineColor = /^#[0-9a-f]{3,8}$/i.test(rawColor) ? rawColor : "#059669";
       const sourceKind = entry.lineContext.source === "rail_graph_runtime" ? "rail_graph" : "legacy";
       const activeLine = markerMatchesActiveLine(new Set([entry.lineContext.lineKey]), new Set([sourceKind]));
+      const scenic = entry.bound.event.kind === "scenic";
+      const scenicStatus = entry.bound.scenicVisibility?.status;
       const layerPoint = map.latLngToLayerPoint([coordinates[1], coordinates[0]]);
       const key = zoom >= 15
         ? [
@@ -1922,6 +1934,8 @@ export const MapContainer: React.FC<Props> = ({
         existing.selectionDetails.push(selectionDetail);
         existing.lineKeys.add(entry.lineContext.lineKey);
         existing.sourceKinds.add(sourceKind);
+        existing.scenic = existing.scenic || scenic;
+        if (scenicStatus) existing.scenicStatuses.add(scenicStatus);
         existing.selected = existing.selected || entry.bound.event.id === selectedMileageEventId;
         existing.activeLine = existing.activeLine || activeLine;
         existing.dimmed = hasActiveMileageAxis && !existing.activeLine && !existing.selected;
@@ -1940,6 +1954,8 @@ export const MapContainer: React.FC<Props> = ({
           selectionDetails: [selectionDetail],
           lineKeys: new Set([entry.lineContext.lineKey]),
           sourceKinds: new Set([sourceKind]),
+          scenic,
+          scenicStatuses: new Set(scenicStatus ? [scenicStatus] : []),
           selected: entry.bound.event.id === selectedMileageEventId,
           activeLine,
           dimmed: hasActiveMileageAxis && !activeLine && entry.bound.event.id !== selectedMileageEventId,
@@ -1948,6 +1964,47 @@ export const MapContainer: React.FC<Props> = ({
         });
       }
     });
+
+    const scenicItems: ScenicVisibilityMapItem[] = projected.flatMap((entry) => {
+      if (entry.bound.event.kind !== "scenic") return [];
+      const coordinates = entry.bound.coordinates;
+      if (!coordinates) return [];
+      const viewpoint = entry.bound.event.payload?.viewpoint;
+      const bearingDegrees = entry.bound.scenicVisibility?.targetBearingDegrees ?? viewpoint?.targetBearingDegrees;
+      if (typeof bearingDegrees !== "number") return [];
+      const rawColor = entry.lineContext.source === "rail_graph_runtime"
+        ? entry.lineContext.segment.displayColor || "#0ea5e9"
+        : entry.lineContext.line.meta.color || "#0ea5e9";
+      const color = /^#[0-9a-f]{3,8}$/i.test(rawColor) ? rawColor : "#0ea5e9";
+      const activeLine = markerMatchesActiveLine(
+        new Set([entry.lineContext.lineKey]),
+        new Set([entry.lineContext.source === "rail_graph_runtime" ? "rail_graph" : "legacy"]),
+      );
+      const selected = entry.bound.event.id === selectedMileageEventId;
+      return [{
+        id: `scenic:${entry.bound.event.id}`,
+        lat: coordinates[1],
+        lng: coordinates[0],
+        color,
+        title: entry.bound.event.title,
+        status: entry.bound.scenicVisibility?.status ?? "unknown",
+        bearingDegrees,
+        angleToleranceDegrees: viewpoint?.constraint?.angleToleranceDegrees ?? 30,
+        distanceMeters: viewpoint?.constraint?.distanceMeters,
+        selected,
+        dimmed: hasActiveMileageAxis && !activeLine && !selected,
+      }];
+    });
+
+    if (scenicVisibilityLayer.current) {
+      syncLeafletLayerGroup<ScenicVisibilityMapItem>(
+        scenicVisibilityLayer.current,
+        scenicItems,
+        (item) => item.id,
+        (item) => createScenicVisibilityLayer(item),
+        (layer, item) => updateScenicVisibilityLayer(layer, item),
+      );
+    }
 
     syncLeafletLayerGroup<EventMarkerItem>(
       mileageEventsLayer.current,
@@ -1978,8 +2035,12 @@ export const MapContainer: React.FC<Props> = ({
         (layer as any)._cachedColor = item.color;
         (layer as any)._cachedCount = item.eventIds.length;
         (layer as any)._cachedSelected = item.selected;
+        (layer as any)._cachedActiveLine = item.activeLine;
+        (layer as any)._cachedDimmed = item.dimmed;
         (layer as any)._cachedMultiLine = item.lineKeys.size > 1;
         (layer as any)._cachedSourceKey = Array.from(item.sourceKinds).sort().join(":");
+        (layer as any)._cachedScenic = item.scenic;
+        (layer as any)._cachedScenicStatusKey = Array.from(item.scenicStatuses).sort().join(":");
         (layer as any)._cachedTitle = title;
         return layer;
       },
@@ -1994,11 +2055,14 @@ export const MapContainer: React.FC<Props> = ({
           _cachedDimmed?: boolean;
           _cachedMultiLine?: boolean;
           _cachedSourceKey?: string;
+          _cachedScenic?: boolean;
+          _cachedScenicStatusKey?: string;
           _cachedTitle?: string;
           _markerClickHandler?: (event: L.LeafletMouseEvent) => void;
         };
         const count = item.eventIds.length;
         const sourceKey = Array.from(item.sourceKinds).sort().join(":");
+        const scenicStatusKey = Array.from(item.scenicStatuses).sort().join(":");
         const title = mileageEventMarkerTitle(item);
         if (marker._cachedLat !== item.lat || marker._cachedLng !== item.lng) {
           marker.setLatLng([item.lat, item.lng]);
@@ -2012,7 +2076,9 @@ export const MapContainer: React.FC<Props> = ({
           marker._cachedActiveLine !== item.activeLine ||
           marker._cachedDimmed !== item.dimmed ||
           marker._cachedMultiLine !== item.lineKeys.size > 1 ||
-          marker._cachedSourceKey !== sourceKey
+          marker._cachedSourceKey !== sourceKey ||
+          marker._cachedScenic !== item.scenic ||
+          marker._cachedScenicStatusKey !== scenicStatusKey
         ) {
           marker.setIcon(createMileageEventIcon(item));
           marker.setZIndexOffset(item.selected ? 1200 : item.activeLine ? 980 : count > 1 ? 900 : 800);
@@ -2023,6 +2089,8 @@ export const MapContainer: React.FC<Props> = ({
           marker._cachedDimmed = item.dimmed;
           marker._cachedMultiLine = item.lineKeys.size > 1;
           marker._cachedSourceKey = sourceKey;
+          marker._cachedScenic = item.scenic;
+          marker._cachedScenicStatusKey = scenicStatusKey;
         }
         if (marker._cachedTitle !== title) {
           marker.unbindTooltip();
@@ -2080,6 +2148,8 @@ export const MapContainer: React.FC<Props> = ({
     selected: boolean;
     activeLine: boolean;
     dimmed: boolean;
+    scenic: boolean;
+    scenicStatuses: Set<string>;
   }) => {
     const count = item.eventIds.length;
     const size = item.selected ? 38 : item.activeLine ? 30 : count > 1 ? Math.min(38, 26 + Math.log2(count + 1) * 6) : 24;
@@ -2093,8 +2163,17 @@ export const MapContainer: React.FC<Props> = ({
       : item.sourceKinds.has("rail_graph")
         ? "is-rail-graph"
         : "is-legacy";
+    const scenicStatuses = Array.from(item.scenicStatuses);
+    const scenicClass = item.scenic ? "is-scenic" : "";
+    const scenicStatusClass = item.scenic
+      ? scenicStatuses.length > 1
+        ? "is-scenic-status-mixed"
+        : scenicStatuses[0]
+          ? `is-scenic-status-${scenicStatuses[0].replace(/[^a-z_]/g, "")}`
+          : "is-scenic-status-unknown"
+      : "";
     const html = `
-      <div class="mileage-event-marker ${clusterClass} ${selectedClass} ${activeClass} ${dimmedClass} ${mixedClass} ${sourceClass}" style="--event-color:${item.color}; --event-size:${size}px">
+      <div class="mileage-event-marker ${clusterClass} ${selectedClass} ${activeClass} ${dimmedClass} ${mixedClass} ${sourceClass} ${scenicClass} ${scenicStatusClass}" style="--event-color:${item.color}; --event-size:${size}px">
         <span class="mileage-event-marker-core">${count > 1 ? count : ""}</span>
       </div>
     `;

--- a/src/components/map/MapContainer.tsx
+++ b/src/components/map/MapContainer.tsx
@@ -579,7 +579,9 @@ export const MapContainer: React.FC<Props> = ({
     map.createPane("mileageEventsPane", overlayPane);
     const mileageEventsPane = map.getPane("mileageEventsPane")!;
     mileageEventsPane.style.zIndex = "430";
-    mileageEventsPane.style.pointerEvents = "auto";
+    // Keep the full-pane overlay transparent to lower map objects; Leaflet
+    // interactive children re-enable pointer events on their own elements.
+    mileageEventsPane.style.pointerEvents = "none";
 
     mapInstance.current = map;
 

--- a/src/components/map/scenicVisibilityLayer.ts
+++ b/src/components/map/scenicVisibilityLayer.ts
@@ -1,0 +1,188 @@
+import * as L from "leaflet";
+import type { ScenicVisibilityStatus } from "../../rail-graph-v1/mileage-event.types";
+
+export type ScenicVisibilityMapItem = {
+  id: string;
+  lat: number;
+  lng: number;
+  color: string;
+  title: string;
+  status: ScenicVisibilityStatus;
+  bearingDegrees: number;
+  angleToleranceDegrees: number;
+  distanceMeters?: number;
+  selected: boolean;
+  dimmed: boolean;
+};
+
+type ScenicLayerCache = L.LayerGroup & {
+  _fan?: L.Polygon;
+  _ray?: L.Polyline;
+  _origin?: L.CircleMarker;
+};
+
+const EARTH_RADIUS_METERS = 6371008.8;
+
+function finiteOr(value: number | undefined, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function normalizeDegrees(value: number): number {
+  return ((value % 360) + 360) % 360;
+}
+
+function destinationLatLng(lat: number, lng: number, bearingDegrees: number, distanceMeters: number): L.LatLngTuple {
+  const angularDistance = distanceMeters / EARTH_RADIUS_METERS;
+  const bearing = normalizeDegrees(bearingDegrees) * Math.PI / 180;
+  const lat1 = lat * Math.PI / 180;
+  const lng1 = lng * Math.PI / 180;
+
+  const lat2 = Math.asin(
+    Math.sin(lat1) * Math.cos(angularDistance)
+      + Math.cos(lat1) * Math.sin(angularDistance) * Math.cos(bearing),
+  );
+  const lng2 = lng1 + Math.atan2(
+    Math.sin(bearing) * Math.sin(angularDistance) * Math.cos(lat1),
+    Math.cos(angularDistance) - Math.sin(lat1) * Math.sin(lat2),
+  );
+
+  return [
+    lat2 * 180 / Math.PI,
+    ((lng2 * 180 / Math.PI + 540) % 360) - 180,
+  ];
+}
+
+function scenicDistanceMeters(item: ScenicVisibilityMapItem): number {
+  const fallback = item.selected ? 1500 : 950;
+  return clamp(finiteOr(item.distanceMeters, fallback), 250, 5000);
+}
+
+function scenicToleranceDegrees(item: ScenicVisibilityMapItem): number {
+  return clamp(finiteOr(item.angleToleranceDegrees, 30), 5, 90);
+}
+
+function fanLatLngs(item: ScenicVisibilityMapItem): L.LatLngExpression[] {
+  const tolerance = scenicToleranceDegrees(item);
+  const distance = scenicDistanceMeters(item);
+  const steps = Math.max(2, Math.ceil(tolerance / 10));
+  const points: L.LatLngExpression[] = [[item.lat, item.lng]];
+
+  for (let step = 0; step <= steps; step += 1) {
+    const ratio = step / steps;
+    const bearing = item.bearingDegrees - tolerance + tolerance * 2 * ratio;
+    points.push(destinationLatLng(item.lat, item.lng, bearing, distance));
+  }
+
+  return points;
+}
+
+function rayLatLngs(item: ScenicVisibilityMapItem): L.LatLngExpression[] {
+  return [
+    [item.lat, item.lng],
+    destinationLatLng(item.lat, item.lng, item.bearingDegrees, scenicDistanceMeters(item)),
+  ];
+}
+
+function statusColor(status: ScenicVisibilityStatus): string {
+  switch (status) {
+    case "visible":
+      return "#0f766e";
+    case "opposite_side":
+      return "#d97706";
+    case "angle_mismatch":
+      return "#e11d48";
+    case "unavailable":
+      return "#475569";
+    case "unknown":
+    default:
+      return "#64748b";
+  }
+}
+
+function scenicLayerStyle(item: ScenicVisibilityMapItem) {
+  const color = statusColor(item.status);
+  const dimFactor = item.dimmed ? 0.38 : 1;
+  const selectedFactor = item.selected ? 1.18 : 1;
+  const dashArray = item.status === "visible" ? undefined : item.status === "unknown" ? "3 6" : "6 5";
+
+  return {
+    color,
+    fillColor: color,
+    fillOpacity: 0.12 * dimFactor * selectedFactor,
+    opacity: 0.62 * dimFactor,
+    weight: item.selected ? 2.5 : 1.5,
+    dashArray,
+  };
+}
+
+function originStyle(item: ScenicVisibilityMapItem): L.CircleMarkerOptions {
+  const color = statusColor(item.status);
+  return {
+    pane: "mileageEventsPane",
+    radius: item.selected ? 5 : 3.5,
+    color: "#ffffff",
+    weight: item.selected ? 2 : 1.5,
+    fillColor: color,
+    fillOpacity: item.dimmed ? 0.35 : 0.9,
+    opacity: item.dimmed ? 0.45 : 0.9,
+    interactive: false,
+  };
+}
+
+export function createScenicVisibilityLayer(item: ScenicVisibilityMapItem): L.Layer {
+  const style = scenicLayerStyle(item);
+  const fan = L.polygon(fanLatLngs(item), {
+    pane: "mileageEventsPane",
+    color: style.color,
+    fillColor: style.fillColor,
+    fillOpacity: style.fillOpacity,
+    opacity: style.opacity,
+    weight: Math.max(1, style.weight - 0.5),
+    dashArray: style.dashArray,
+    interactive: false,
+  });
+  const ray = L.polyline(rayLatLngs(item), {
+    pane: "mileageEventsPane",
+    color: style.color,
+    opacity: Math.min(0.88, style.opacity + 0.15),
+    weight: item.selected ? 3 : 2,
+    dashArray: style.dashArray,
+    interactive: false,
+  });
+  const origin = L.circleMarker([item.lat, item.lng], originStyle(item));
+  const group = L.layerGroup([fan, ray, origin]) as ScenicLayerCache;
+  group._fan = fan;
+  group._ray = ray;
+  group._origin = origin;
+  return group;
+}
+
+export function updateScenicVisibilityLayer(layer: L.Layer, item: ScenicVisibilityMapItem): void {
+  const group = layer as ScenicLayerCache;
+  const style = scenicLayerStyle(item);
+
+  group._fan?.setLatLngs(fanLatLngs(item));
+  group._fan?.setStyle({
+    color: style.color,
+    fillColor: style.fillColor,
+    fillOpacity: style.fillOpacity,
+    opacity: style.opacity,
+    weight: Math.max(1, style.weight - 0.5),
+    dashArray: style.dashArray,
+  });
+
+  group._ray?.setLatLngs(rayLatLngs(item));
+  group._ray?.setStyle({
+    color: style.color,
+    opacity: Math.min(0.88, style.opacity + 0.15),
+    weight: item.selected ? 3 : 2,
+    dashArray: style.dashArray,
+  });
+
+  group._origin?.setLatLng([item.lat, item.lng]);
+  group._origin?.setStyle(originStyle(item));
+}

--- a/src/index.css
+++ b/src/index.css
@@ -678,6 +678,54 @@
     0 0 0 1px rgba(15,23,42,0.08);
 }
 
+.mileage-event-marker.is-scenic {
+  --scenic-status-color: #64748b;
+  border-radius: 9px 9px 9px 3px;
+  background:
+    radial-gradient(circle at 35% 28%, rgba(255,255,255,0.92), transparent 30%),
+    linear-gradient(135deg, color-mix(in srgb, var(--event-color) 86%, #0f766e), color-mix(in srgb, var(--event-color) 64%, #0f172a));
+}
+
+.mileage-event-marker.is-scenic.is-single .mileage-event-marker-core {
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+  background: #fff;
+  transform: rotate(45deg);
+  box-shadow: 0 0 0 1px rgba(255,255,255,0.4);
+}
+
+.mileage-event-marker.is-scenic::after {
+  inset: auto -4px -4px auto;
+  width: 11px;
+  height: 11px;
+  border-radius: 999px;
+  border: 2px solid rgba(255,255,255,0.96);
+  background: var(--scenic-status-color);
+  box-shadow: 0 2px 8px rgba(15,23,42,0.22);
+  opacity: 1;
+}
+
+.mileage-event-marker.is-scenic-status-visible {
+  --scenic-status-color: #0f766e;
+}
+
+.mileage-event-marker.is-scenic-status-opposite_side {
+  --scenic-status-color: #d97706;
+}
+
+.mileage-event-marker.is-scenic-status-angle_mismatch {
+  --scenic-status-color: #e11d48;
+}
+
+.mileage-event-marker.is-scenic-status-unavailable {
+  --scenic-status-color: #475569;
+}
+
+.mileage-event-marker.is-scenic-status-mixed {
+  --scenic-status-color: #7c3aed;
+}
+
 .mileage-event-marker.is-selected {
   transform: translateZ(0) scale(1.18);
   box-shadow:


### PR DESCRIPTION
Summary:
- Adds a Leaflet scenic visibility layer with fan polygon, target ray, and origin marker.
- Makes scenic map markers visually distinct and status-colored.
- Moves the Leaflet layer control out of the rail-graph panel conflict zone.

Stack: PR 3 of 5. Base is PR 2.
Validation:
- git diff --check HEAD~5..HEAD
- npx tsc --noEmit
- npx vitest run src/__tests__/rail-graph-selection.test.ts src/__tests__/mileage-events-runtime-adapter.test.ts src/__tests__/rail-graph-trip-planner.test.ts src/__tests__/scenic-visibility-layer.test.ts
- npx vite build
- npm --prefix blog run build

Note: pre-commit could not be run locally because this checkout has no .pre-commit-config, no .git/hooks/pre-commit, and no pre-commit executable.