### PR TITLE
Docs: update rail graph main app contracts

### DIFF
--- a/docs/rail-graph-main-app-flow.md
+++ b/docs/rail-graph-main-app-flow.md
@@ -38,6 +38,8 @@
 5. 时间、名称、source 等信息只在有定位或判断价值时出现；避免同一条目上下重复。
 6. 不提供无意义 batch/bulk UI。列表可以多选用于导航或过滤，但不能包装成用户并不需要的批量操作。
 7. 非方向 / 强制方向 workflow 的导出语义属于 MVP / aggregate 产物加载约束；主应用只消费可加载结果。
+8. legacy GeoJSON 与旧 `app-line:*` 用户事件是一等兼容路径；时间层、scenic 等常规事件可以推断，不因 legacy source 默认禁用。
+9. 只有只读 system event、缺失必要锚点、权限/同步冲突、或无法定位任何 axis 时禁用编辑；低置信度推断显示 diagnostics，不阻断编辑。
 
 ## 4. Data Flow
 
@@ -68,7 +70,22 @@ TripEditor / route planner candidate
 
 Manual segment editing clears stale rail-graph snapshot and returns the trip to legacy GeoJSON segments.
 
-### 4.3 User Event / 标注
+### 4.3 Active Selection
+
+`activeRailGraphSelection` 是主应用唯一非持久 UI selection 真源。window bridge 只保留 Leaflet / DOM 边界，不保存业务状态。
+
+该状态使用 discriminated union：
+
+- `routeSelected`: 地图 route 被选中，并派生 active axis。
+- `axisSelected`: 当前查看或编辑的 rail-graph snapshot segment / legacy GeoJSON axis。
+- `eventSelected`: 当前选中用户事件或可定位事件，必须绑定 route / axis 上下文。
+- `creating`: 正在创建用户标注，继承当前 route / axis anchor。
+- `inspecting`: 正在检查对象，不自动进入创建。
+- `unavailable`: 缺失必要上下文或权限时的显式不可用状态，必须带 reason。
+
+旧 `kind: route | axis | event` 只作为迁移期兼容别名；新逻辑必须以 `state` 为准。
+
+### 4.4 User Event / 标注
 
 ```text
 Map route click / pin / map point / TripPage jump
@@ -83,6 +100,17 @@ Map route click / pin / map point / TripPage jump
 
 TripPage event rows should call map selection/opening APIs; they should not become a competing editor.
 
+### 4.5 Scenic / Viewpoint
+
+Scenic 不再只是 event kind。系统 scenic 与用户 scenic 共享 `ScenicViewpointPayload`：
+
+- 必须有 mileage / anchor 与 `facing: left | right | front | back`。
+- `targetBearingDegrees`、`visibleBearingRangeDegrees`、角度容差可由 projection 推断。
+- projection 必须输出 confidence、diagnostics 和 visibility status。
+- visibility status 固定为 `visible | opposite_side | angle_mismatch | unknown | unavailable`。
+
+Rail-graph snapshot 使用 run geometry / direction 推断 scenic visibility。Legacy GeoJSON 使用线路局部几何和地图点推断 bearing / side，并标记 `inferred_from_geojson`；用户可用地图方向控件修正。
+
 ## 5. UI Responsibilities
 
 | Surface | Role | Required state |
@@ -95,6 +123,19 @@ TripPage event rows should call map selection/opening APIs; they should not beco
 | GlobalSearch | Fast navigation | source badges, event/trip metadata, map jump for标注 |
 | TripEditor | Route planning and saved snapshot review | candidate source, pattern/service/direction, save semantics, no direct rail-graph mutation |
 | ExportRouteModal | Export truth | saved snapshot vs legacy route, exportable key events, geometry source |
+
+Map route click 的语义顺序固定为：
+
+```text
+click route
+  -> state = routeSelected
+  -> derive active axis
+  -> highlight route and dim non-active routes
+  -> expand compact MileageEventsPanel handle
+  -> user explicitly chooses Create
+```
+
+点击 route 不直接创建草稿。
 
 ## 6. Visual Language
 
@@ -110,6 +151,8 @@ Required badge families:
 
 Badges should carry metadata, not repeat surrounding title/time text. Raw refs can appear in tooltip or detail rows, not as the primary label.
 
+Map chrome 使用统一安全区：Leaflet layer / zoom 控件不占 rail-graph 面板右上区域；RailGraph handle 默认是右侧半透明扁长手柄，hover / focus / route select 时展开为摘要入口。移动端使用底部或右侧自适应手柄，并支持 tap / drag 展开和收起。
+
 Current shared entry points:
 
 - `RailGraphRunBadges` for React service / direction / pattern metadata.
@@ -119,7 +162,7 @@ Current shared entry points:
 
 ## 7. Current Progress
 
-Current implementation is approximately 65-68 percent complete for the main-app UI goal.
+Current implementation is approximately 75-78 percent complete for the main-app UI goal.
 
 Done:
 
@@ -132,6 +175,10 @@ Done:
 - `activeRailGraphSelection` is the shared non-persistent UI selection across Map route click, TripPage jump, GlobalSearch event jump, EventInspector map jump, and MileageEventsPanel.
 - Map event marker clicks preserve trip id, segment index, and route context when projection data is available.
 - `railGraphSelection.ts` centralizes bridge source conversion plus ProductTripSegment / event projection context / Map route item selection payloads, including legacy GeoJSON compatibility and explicit rail-graph source overrides.
+- Scenic payload now flows through system events, user events, projection, and MapView rendering as a shared viewpoint/visibility contract instead of a plain event category.
+- MapView renders scenic visibility as a first-class Leaflet layer with status-colored fan/ray/origin geometry, plus distinct scenic marker styling.
+- MileageEventsPanel closed state is a right-edge translucent handle that opens on pointer hover for mouse/pen and still supports tap/click for touch.
+- MileageEventsPanel header import/export controls are grouped under a compact action menu instead of two permanent header buttons.
 - TripPage event center has moved toward read-only overview and map jump instead of competing event editing/export tooling.
 - Route metadata uses the shared badge visual language in React surfaces and Leaflet HTML.
 
@@ -140,6 +187,7 @@ Still incomplete:
 - Window bridge events and store `activeRailGraphSelection` still coexist; the bridge should shrink further to native Leaflet / DOM event boundaries.
 - Map selected route, selected event marker, dimmed routes, hover metadata, and touch metadata still need visual QA.
 - EventComposer and MileageEventsPanel need more narrow-screen polish and disabled-reason QA.
+- Mobile drag-to-open/drag-to-adjust interactions for the edge handle and scenic direction/range controls are not implemented yet.
 - TripPage still needs replay/route visualization simplification and more top-level run summary polish.
 - Visual QA for mobile/desktop has not been completed.
 

--- a/docs/rail-graph-main-app-ui-flow.md
+++ b/docs/rail-graph-main-app-ui-flow.md
@@ -37,6 +37,7 @@ MVP / aggregate 只要求导出产物可被真实 loader / smoke 读取，不扩
 
 ```text
 activeRailGraphSelection
+  state: routeSelected | axisSelected | eventSelected | creating | inspecting | unavailable
   kind: route | event | axis
   source: rail_graph_snapshot | legacy_geojson
   lineKey
@@ -50,11 +51,21 @@ activeRailGraphSelection
   anchor: lat / lng / tripRatio
 ```
 
-该状态不进入 IndexedDB，不随用户数据同步。它只表示当前 UI 选择，用来对齐 MapView、MileageEventsPanel、TripPage 跳转和 Search 事件定位。
+该状态不进入 IndexedDB，不随用户数据同步。它只表示当前 UI 选择，用来对齐 MapView、MileageEventsPanel、TripPage 跳转和 Search 事件定位。`state` 是判别字段；旧 `kind` 只作为迁移期兼容别名。
+
+状态语义：
+
+- `routeSelected`: route click 后的主状态，驱动 active axis 和 map highlight。
+- `axisSelected`: 当前面板查看/编辑的 mileage axis。
+- `eventSelected`: 当前选中的事件，必须携带 event id 与可恢复的 route / axis context。
+- `creating`: 用户显式进入创建，继承 route / axis anchor。
+- `inspecting`: 只检查 route / event / axis，不自动创建。
+- `unavailable`: 缺少锚点、权限或可投影 axis 时的显式状态，必须显示 reason。
 
 当前实现状态：
 
 - Map route click 写入 `kind="route"`，打开事件面板但不直接进入创建草稿。
+- 当前实现已开始写入 `state="routeSelected" | "axisSelected" | "eventSelected"`，新逻辑以 `state` 为准。
 - MileageEventsPanel open handler 会保留同一路线的 `kind="route"` selection，避免覆盖掉 route click 的 `anchor` / run metadata；只有事件选择或不同 axis 才降级/切换 selection。
 - Map route highlight 优先使用 `routeItemId`，避免同一 pattern / line 的多个 segment 被误认为同一选中对象。
 - Event select 写入 `kind="event"`，地图 marker 与面板 inspector 可以同步。
@@ -81,7 +92,25 @@ click route
 
 这样避免“只是查看路线却进入创建”的误触，同时保留从选中线路快速创建标注的效率。
 
-## 6. TripPage Contract
+## 6. Map Chrome Contract
+
+MapView 使用统一地图控件安全区：
+
+- Leaflet zoom / layer 控件不得占用 rail-graph 面板右上区域。
+- MileageEventsPanel 关闭态是右侧半透明扁长手柄；鼠标不进入时只显示贴边手柄。
+- hover / focus / route select 时，手柄展开成 compact summary，可直接打开面板。
+- 移动端允许 tap 展开、drag 拉出/收起；后续 scenic 方向扇区也必须支持拖动调整。
+
+当前实现状态：
+
+- Leaflet layer control 已从 `topright` 移到 `topleft`，避免与 rail-graph 面板冲突。
+- MileageEventsPanel 关闭态已从右上圆形按钮改为右侧中段贴边手柄，展开时显示当前 axis 摘要。
+
+Current Map chrome implementation state:
+- MileageEventsPanel closed handle opens on mouse/pen pointer enter and tap/click, so desktop route-to-events flow removes one explicit click.
+- Import/export are grouped under a compact header action menu; close remains a dedicated button.
+
+## 7. TripPage Contract
 
 TripPage 的 event center 是只读概要：
 
@@ -91,7 +120,7 @@ TripPage 的 event center 是只读概要：
 - event row 可以跳转地图并选中事件。
 - 不提供 copy / JSON / MDX 事件工具；这些应放在地图事件面板或独立导出入口。
 
-## 7. Visual Language
+## 8. Visual Language
 
 所有 rail-graph / user event 元数据优先使用 React 组件：
 
@@ -130,7 +159,23 @@ EventComposer 当前已经把 station / map / mileage / trip 四种创建来源�
 - 明确 disabled reason，而不是只让 Create 按钮变灰。
 - 当前实现已把不可用原因显示到每张 source card 上，并额外区分“没有 trip”和“选中 trip 没有可投影 segment”；窄视口先单列展示 source card，避免 disabled reason 挤压主要标签。
 
-## 8. Remaining PR Work
+## 9. Scenic / Viewpoint UI
+
+Scenic 标注必须表现为地图可理解的 viewpoint，而不是普通分类：
+
+- 系统 scenic 与用户 scenic 共用 `ScenicViewpointPayload`。
+- 地图显示 scenic marker、视线/扇形可视域、route 绑定和 visibility badge。
+- visibility status 固定为 `visible | opposite_side | angle_mismatch | unknown | unavailable`。
+- 用户创建 scenic 时，默认从 route anchor 的切线方向和地图目标点推断 facing / bearing / range。
+- 编辑控件使用地图内方向盘/扇形控件，拖动调整 bearing/range，旁边用 left/right/front/back segmented control 快速切换。
+- Legacy GeoJSON scenic 使用线路局部几何推断，并标记 `inferred_from_geojson`；低置信度只显示 diagnostics，不禁用编辑。
+
+Current scenic implementation state:
+- System scenic events and user scenic events share `ScenicViewpointPayload`; legacy GeoJSON scenic events infer `facing`, target bearing, and source diagnostics where possible.
+- MapView renders scenic visibility through `scenicVisibilityLayer.ts`: fan polygon, target ray, origin marker, and status-colored scenic marker classes.
+- Remaining gap: direct map drag controls for editing scenic facing/bearing/range are not implemented yet.
+
+## 10. Remaining PR Work
 
 ### PR UI-1 - Active selection hardening
 

--- a/docs/rail-graph-v1-plan/15-main-app-data-and-interaction-flow.md
+++ b/docs/rail-graph-v1-plan/15-main-app-data-and-interaction-flow.md
@@ -4,6 +4,8 @@
 
 本文定义主应用的实现口径。早期 `rail-graph-v1-plan` 文档仍作为设计背景，但当前 UI、数据流和测试以本文与代码为准。
 
+> 2026-06-10 更新：当前权威口径以 `docs/rail-graph-main-app-flow.md` 与 `docs/rail-graph-main-app-ui-flow.md` 为准。后续实现必须遵循其中的 `activeRailGraphSelection.state` 判别联合、Scenic/Viewpoint 共享 payload、legacy GeoJSON 一等兼容、Map chrome 贴边手柄与 Leaflet 控件避让规则。本文保留 PR19-PR22 背景和历史摘要，不再单独分叉新的交互契约。
+
 ## 1. 术语
 
 | 术语 | 主应用含义 |


### PR DESCRIPTION
Summary:
- Updates the main app flow and UI flow docs for the selection, scenic/viewpoint, and map chrome contracts.
- Marks the rail-graph v1 plan as deferring authority to the latest flow docs.
- Records remaining gaps, including mobile drag controls and broader visual QA.

Stack: PR 5 of 5. Base is PR 4.
Validation:
- git diff --check HEAD~5..HEAD
- npx tsc --noEmit
- npx vitest run src/__tests__/rail-graph-selection.test.ts src/__tests__/mileage-events-runtime-adapter.test.ts src/__tests__/rail-graph-trip-planner.test.ts src/__tests__/scenic-visibility-layer.test.ts
- npx vite build
- npm --prefix blog run build

Note: pre-commit could not be run locally because this checkout has no .pre-commit-config, no .git/hooks/pre-commit, and no pre-commit executable.