### PR TITLE
rail-graph: complete scenic editor interactions

### DIFF
--- a/docs/rail-graph-main-app-flow.md
+++ b/docs/rail-graph-main-app-flow.md
@@ -177,7 +177,8 @@ Done:
 - `railGraphSelection.ts` centralizes bridge source conversion plus ProductTripSegment / event projection context / Map route item selection payloads, including legacy GeoJSON compatibility and explicit rail-graph source overrides.
 - Scenic payload now flows through system events, user events, projection, and MapView rendering as a shared viewpoint/visibility contract instead of a plain event category.
 - MapView renders scenic visibility as a first-class Leaflet layer with status-colored fan/ray/origin geometry, plus distinct scenic marker styling.
-- MileageEventsPanel closed state is a right-edge translucent handle that opens on pointer hover for mouse/pen and still supports tap/click for touch.
+- Selected scenic user events expose explicit viewpoint controls in EventComposer/EventInspector and draggable MapView handles for bearing, angle tolerance, and range.
+- MileageEventsPanel closed state is a right-edge translucent handle that opens on pointer hover for mouse/pen, tap/click for touch, and drag-to-open/drag-to-close on touch/pen.
 - MileageEventsPanel header import/export controls are grouped under a compact action menu instead of two permanent header buttons.
 - TripPage event center has moved toward read-only overview and map jump instead of competing event editing/export tooling.
 - Route metadata uses the shared badge visual language in React surfaces and Leaflet HTML.
@@ -186,8 +187,7 @@ Still incomplete:
 
 - Window bridge events and store `activeRailGraphSelection` still coexist; the bridge should shrink further to native Leaflet / DOM event boundaries.
 - Map selected route, selected event marker, dimmed routes, hover metadata, and touch metadata still need visual QA.
-- EventComposer and MileageEventsPanel need more narrow-screen polish and disabled-reason QA.
-- Mobile drag-to-open/drag-to-adjust interactions for the edge handle and scenic direction/range controls are not implemented yet.
+- EventComposer and MileageEventsPanel need more narrow-screen visual QA and disabled-reason QA.
 - TripPage still needs replay/route visualization simplification and more top-level run summary polish.
 - Visual QA for mobile/desktop has not been completed.
 

--- a/docs/rail-graph-main-app-ui-flow.md
+++ b/docs/rail-graph-main-app-ui-flow.md
@@ -99,7 +99,7 @@ MapView 使用统一地图控件安全区：
 - Leaflet zoom / layer 控件不得占用 rail-graph 面板右上区域。
 - MileageEventsPanel 关闭态是右侧半透明扁长手柄；鼠标不进入时只显示贴边手柄。
 - hover / focus / route select 时，手柄展开成 compact summary，可直接打开面板。
-- 移动端允许 tap 展开、drag 拉出/收起；后续 scenic 方向扇区也必须支持拖动调整。
+- 移动端允许 tap 展开、drag 拉出/收起；scenic 方向扇区支持拖动调整。
 
 当前实现状态：
 
@@ -108,6 +108,7 @@ MapView 使用统一地图控件安全区：
 
 Current Map chrome implementation state:
 - MileageEventsPanel closed handle opens on mouse/pen pointer enter and tap/click, so desktop route-to-events flow removes one explicit click.
+- The closed edge handle supports touch/pen drag-to-open, and the open panel header supports touch/pen drag-to-close.
 - Import/export are grouped under a compact header action menu; close remains a dedicated button.
 
 ## 7. TripPage Contract
@@ -173,7 +174,8 @@ Scenic 标注必须表现为地图可理解的 viewpoint，而不是普通分类
 Current scenic implementation state:
 - System scenic events and user scenic events share `ScenicViewpointPayload`; legacy GeoJSON scenic events infer `facing`, target bearing, and source diagnostics where possible.
 - MapView renders scenic visibility through `scenicVisibilityLayer.ts`: fan polygon, target ray, origin marker, and status-colored scenic marker classes.
-- Remaining gap: direct map drag controls for editing scenic facing/bearing/range are not implemented yet.
+- EventComposer edits scenic `facing`, target bearing, angle tolerance, and display range; EventInspector shows the projected visibility status and viewpoint fields.
+- Selected scenic user events expose draggable MapView handles for bearing/range and fan angle/range edits, writing back to the shared `payload.viewpoint`.
 
 ## 10. Remaining PR Work
 

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -587,6 +587,29 @@
       "shared": "Shared",
       "public": "Public"
     },
+    "scenicViewpoint": {
+      "title": "Scenic viewpoint",
+      "facing": "Facing",
+      "bearing": "Bearing",
+      "angleTolerance": "Angle",
+      "distance": "Range",
+      "status": "Status",
+      "confidence": "Confidence",
+      "auto": "Auto",
+      "facingValue": {
+        "left": "Left",
+        "right": "Right",
+        "front": "Front",
+        "back": "Back"
+      },
+      "statusValue": {
+        "visible": "Visible",
+        "opposite_side": "Opposite side",
+        "angle_mismatch": "Angle mismatch",
+        "unknown": "Unknown",
+        "unavailable": "Unavailable"
+      }
+    },
     "filter": {
       "allLines": "All lines",
       "source": "Source",

--- a/public/locales/ja-JP/translation.json
+++ b/public/locales/ja-JP/translation.json
@@ -587,6 +587,29 @@
       "shared": "共有",
       "public": "公開"
     },
+    "scenicViewpoint": {
+      "title": "景観視点",
+      "facing": "向き",
+      "bearing": "方位角",
+      "angleTolerance": "角度",
+      "distance": "範囲",
+      "status": "状態",
+      "confidence": "信頼度",
+      "auto": "自動",
+      "facingValue": {
+        "left": "左側",
+        "right": "右側",
+        "front": "前方",
+        "back": "後方"
+      },
+      "statusValue": {
+        "visible": "可視",
+        "opposite_side": "反対側",
+        "angle_mismatch": "角度不一致",
+        "unknown": "不明",
+        "unavailable": "利用不可"
+      }
+    },
     "filter": {
       "allLines": "すべての路線",
       "source": "ソース",

--- a/public/locales/zh-CN/translation.json
+++ b/public/locales/zh-CN/translation.json
@@ -587,6 +587,29 @@
       "shared": "共享",
       "public": "公开"
     },
+    "scenicViewpoint": {
+      "title": "景观视点",
+      "facing": "朝向",
+      "bearing": "方位角",
+      "angleTolerance": "角度",
+      "distance": "范围",
+      "status": "状态",
+      "confidence": "置信度",
+      "auto": "自动",
+      "facingValue": {
+        "left": "左侧",
+        "right": "右侧",
+        "front": "前方",
+        "back": "后方"
+      },
+      "statusValue": {
+        "visible": "可见",
+        "opposite_side": "反侧",
+        "angle_mismatch": "角度不符",
+        "unknown": "未知",
+        "unavailable": "不可用"
+      }
+    },
     "filter": {
       "allLines": "全部线路",
       "source": "来源",

--- a/public/locales/zh-TW/translation.json
+++ b/public/locales/zh-TW/translation.json
@@ -587,6 +587,29 @@
       "shared": "共享",
       "public": "公開"
     },
+    "scenicViewpoint": {
+      "title": "景觀視點",
+      "facing": "朝向",
+      "bearing": "方位角",
+      "angleTolerance": "角度",
+      "distance": "範圍",
+      "status": "狀態",
+      "confidence": "可信度",
+      "auto": "自動",
+      "facingValue": {
+        "left": "左側",
+        "right": "右側",
+        "front": "前方",
+        "back": "後方"
+      },
+      "statusValue": {
+        "visible": "可見",
+        "opposite_side": "反側",
+        "angle_mismatch": "角度不符",
+        "unknown": "未知",
+        "unavailable": "不可用"
+      }
+    },
     "filter": {
       "allLines": "全部路線",
       "source": "來源",

--- a/src/__tests__/mileage-events-runtime-adapter.test.ts
+++ b/src/__tests__/mileage-events-runtime-adapter.test.ts
@@ -25,6 +25,7 @@ import {
   queryEventsByMileage,
   queryEventsByText,
   queryEventsByTime,
+  updateMileageEventFromDraft,
 } from "../utils/mileageUserEvents";
 import { tripResultToLegacyTrip } from "../utils/railGraphTripAdapter";
 import type { RailwayMap } from "../store";
@@ -287,6 +288,75 @@ describe("mileage events runtime adapter", () => {
     expect(stationEvent.payload?.viewpoint?.coordinates).toBeUndefined();
     expect(stationEvent.payload?.viewpoint?.targetBearingDegrees).toBeGreaterThan(150);
     expect(stationEvent.payload?.viewpoint?.targetBearingDegrees).toBeLessThan(210);
+  });
+
+  it("keeps explicit scenic viewpoint edits in the shared event payload", () => {
+    const lineKey = "app:test-explicit-scenic-line";
+    const railwayData: RailwayMap = {
+      [lineKey]: {
+        meta: {
+          company: "Test Railway",
+          region: "test",
+          type: "fixture",
+          logo: null,
+          color: "#0f766e",
+        },
+        stations: [
+          { id: "a", name_ja: "Alpha", lat: 35.0, lng: 139.0, transfers: [], distToNext: 5 },
+          { id: "b", name_ja: "Beta", lat: 35.0, lng: 139.05, transfers: [] },
+        ],
+      },
+    };
+    const lineContext = buildAppMileageLineContext(railwayData, lineKey)!;
+    const event = createMileageEventFromStation({
+      lineContext,
+      stationId: "a",
+      title: "Explicit window view",
+      kind: "scenic",
+      scenicViewpoint: {
+        facing: "front",
+        targetBearingDegrees: 12,
+        angleToleranceDegrees: 18,
+        distanceMeters: 2200,
+      },
+    });
+
+    expect(event?.payload?.viewpoint).toMatchObject({
+      facing: "front",
+      source: "user_explicit",
+      targetBearingDegrees: 12,
+      constraint: {
+        targetBearingDegrees: 12,
+        angleToleranceDegrees: 18,
+        distanceMeters: 2200,
+      },
+    });
+
+    const updated = updateMileageEventFromDraft(event!, {
+      kind: "scenic",
+      scenicViewpoint: {
+        facing: "left",
+        targetBearingDegrees: 270,
+        angleToleranceDegrees: 44,
+        distanceMeters: 3100,
+      },
+    });
+    expect(updated.payload?.viewpoint).toMatchObject({
+      facing: "left",
+      source: "user_explicit",
+      targetBearingDegrees: 270,
+      constraint: {
+        targetBearingDegrees: 270,
+        angleToleranceDegrees: 44,
+        distanceMeters: 3100,
+      },
+    });
+
+    const display = boundMileageEventForDisplay(updated, railwayData);
+    expect(display?.bound.scenicVisibility?.targetBearingDegrees).toBe(270);
+
+    const nonScenic = updateMileageEventFromDraft(updated, { kind: "user_note" });
+    expect(nonScenic.payload?.viewpoint).toBeUndefined();
   });
 });
 

--- a/src/__tests__/scenic-visibility-layer.test.ts
+++ b/src/__tests__/scenic-visibility-layer.test.ts
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import * as L from "leaflet";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   createScenicVisibilityLayer,
   updateScenicVisibilityLayer,
@@ -57,5 +57,29 @@ describe("scenic visibility Leaflet layer", () => {
     expect((rayAfter as L.Polyline).options.weight).toBe(3);
     expect((originAfter as L.CircleMarker).getLatLng().lat).toBeCloseTo(35.7);
     expect((originAfter as L.CircleMarker).getLatLng().lng).toBeCloseTo(139.8);
+  });
+
+  it("adds draggable edit handles only for selected editable scenic items", () => {
+    const onEdit = vi.fn();
+    const layer = createScenicVisibilityLayer(item({
+      selected: true,
+      editable: true,
+      onEdit,
+    })) as L.LayerGroup;
+
+    const layers = layer.getLayers();
+    expect(layers).toHaveLength(6);
+    expect(layers.slice(3).every((candidate) => candidate instanceof L.Marker)).toBe(true);
+
+    const targetHandle = layers[3] as L.Marker;
+    targetHandle.setLatLng([35.68, 139.79]);
+    targetHandle.fire("dragend");
+    expect(onEdit).toHaveBeenCalledWith(expect.objectContaining({
+      bearingDegrees: expect.any(Number),
+      distanceMeters: expect.any(Number),
+    }));
+
+    updateScenicVisibilityLayer(layer, item({ selected: false }));
+    expect(layer.getLayers()).toHaveLength(3);
   });
 });

--- a/src/components/map/MapContainer.tsx
+++ b/src/components/map/MapContainer.tsx
@@ -17,9 +17,11 @@ import { useAppRouteState } from "../../hooks/useAppRouteState";
 import {
   createScenicVisibilityLayer,
   updateScenicVisibilityLayer,
+  type ScenicVisibilityEdit,
   type ScenicVisibilityMapItem,
 } from "./scenicVisibilityLayer";
-import { boundMileageEventsForRichDisplay } from "../../utils/mileageUserEvents";
+import { boundMileageEventsForRichDisplay, updateMileageEventFromDraft } from "../../utils/mileageUserEvents";
+import { useMileageEventActions } from "../mileage-events/useMileageEventActions";
 import { tripToProductSegments } from "../../utils/tripProductProjection";
 import {
   customEventDetail,
@@ -239,6 +241,25 @@ export const MapContainer: React.FC<Props> = ({
       visitedStations: state.visitedStations,
     })),
   );
+  const { updateEvent } = useMileageEventActions();
+
+  const updateScenicViewpointFromMap = (eventId: string, change: ScenicVisibilityEdit) => {
+    const event = mileageUserEvents.find((candidate) => candidate.id === eventId);
+    if (!event || event.kind !== "scenic") return;
+    updateEvent(updateMileageEventFromDraft(event, {
+      kind: "scenic",
+      scenicViewpoint: {
+        facing: event.payload?.viewpoint?.facing,
+        targetBearingDegrees: change.bearingDegrees
+          ?? event.payload?.viewpoint?.targetBearingDegrees
+          ?? event.payload?.viewpoint?.constraint?.targetBearingDegrees,
+        angleToleranceDegrees: change.angleToleranceDegrees
+          ?? event.payload?.viewpoint?.constraint?.angleToleranceDegrees,
+        distanceMeters: change.distanceMeters
+          ?? event.payload?.viewpoint?.constraint?.distanceMeters,
+      },
+    }));
+  };
 
   useEffect(() => {
     setLeafletReady(true);
@@ -1995,6 +2016,8 @@ export const MapContainer: React.FC<Props> = ({
         distanceMeters: viewpoint?.constraint?.distanceMeters,
         selected,
         dimmed: hasActiveMileageAxis && !activeLine && !selected,
+        editable: selected,
+        onEdit: selected ? (change) => updateScenicViewpointFromMap(entry.bound.event.id, change) : undefined,
       }];
     });
 

--- a/src/components/map/MileageEventsPanel.tsx
+++ b/src/components/map/MileageEventsPanel.tsx
@@ -72,6 +72,19 @@ export const MileageEventsPanel: React.FC = () => {
   const { importEvents } = useMileageEventActions();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const actionsMenuRef = useRef<HTMLDivElement>(null);
+  const edgeHandleDragRef = useRef<{
+    pointerId: number;
+    startX: number;
+    startY: number;
+    opened: boolean;
+  } | null>(null);
+  const panelDragRef = useRef<{
+    pointerId: number;
+    startX: number;
+    startY: number;
+    closed: boolean;
+  } | null>(null);
+  const skipEdgeHandleClickRef = useRef(false);
 
   const lineKeys = useMemo(() => Object.keys(railwayData).sort(), [railwayData]);
   const [open, setOpen] = useState(false);
@@ -509,12 +522,87 @@ export const MileageEventsPanel: React.FC = () => {
     setOpen(true);
   };
 
+  const beginEdgeHandleDrag = (event: React.PointerEvent<HTMLButtonElement>) => {
+    if (event.pointerType === "mouse") return;
+    edgeHandleDragRef.current = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      opened: false,
+    };
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+  };
+
+  const updateEdgeHandleDrag = (event: React.PointerEvent<HTMLButtonElement>) => {
+    const drag = edgeHandleDragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId || drag.opened) return;
+    const dx = drag.startX - event.clientX;
+    const dy = Math.abs(event.clientY - drag.startY);
+    if (dx > 34 && dx > dy * 0.7) {
+      drag.opened = true;
+      skipEdgeHandleClickRef.current = true;
+      setOpen(true);
+      window.setTimeout(() => {
+        skipEdgeHandleClickRef.current = false;
+      }, 350);
+      event.currentTarget.releasePointerCapture?.(event.pointerId);
+    }
+  };
+
+  const endEdgeHandleDrag = (event: React.PointerEvent<HTMLButtonElement>) => {
+    if (edgeHandleDragRef.current?.pointerId === event.pointerId) {
+      edgeHandleDragRef.current = null;
+    }
+  };
+
+  const beginPanelDrag = (event: React.PointerEvent<HTMLElement>) => {
+    if (event.pointerType === "mouse") return;
+    const target = event.target as HTMLElement;
+    if (target.closest("button,input,select,textarea,a,[role='menuitem']")) return;
+    panelDragRef.current = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      closed: false,
+    };
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+  };
+
+  const updatePanelDrag = (event: React.PointerEvent<HTMLElement>) => {
+    const drag = panelDragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId || drag.closed) return;
+    const dx = event.clientX - drag.startX;
+    const dy = event.clientY - drag.startY;
+    if (dx > 72 || dy > 86) {
+      drag.closed = true;
+      setActionsOpen(false);
+      setOpen(false);
+      event.currentTarget.releasePointerCapture?.(event.pointerId);
+    }
+  };
+
+  const endPanelDrag = (event: React.PointerEvent<HTMLElement>) => {
+    if (panelDragRef.current?.pointerId === event.pointerId) {
+      panelDragRef.current = null;
+    }
+  };
+
   if (!open) {
     return (
       <button
         className="rl-focus group absolute right-0 top-1/2 z-[520] flex h-28 w-6 -translate-y-1/2 items-center overflow-hidden rounded-l-md border border-r-0 border-slate-200/80 bg-white/70 text-slate-700 shadow-lg shadow-slate-900/10 backdrop-blur-md transition-[width,background-color,opacity,transform] duration-200 hover:w-44 hover:bg-white/95 focus-visible:w-44 focus-visible:bg-white/95 active:scale-[0.98]"
-        onClick={() => setOpen(true)}
+        onClick={() => {
+          if (skipEdgeHandleClickRef.current) {
+            skipEdgeHandleClickRef.current = false;
+            return;
+          }
+          setOpen(true);
+        }}
         onPointerEnter={openFromEdgeHandle}
+        onPointerDown={beginEdgeHandleDrag}
+        onPointerMove={updateEdgeHandleDrag}
+        onPointerUp={endEdgeHandleDrag}
+        onPointerCancel={endEdgeHandleDrag}
         title={t("mileageEvents.open", "Mileage events")}
         aria-label={t("mileageEvents.open", "Mileage events")}
       >
@@ -537,7 +625,13 @@ export const MileageEventsPanel: React.FC = () => {
 
   return (
     <section className="rl-modal-panel absolute inset-x-2 bottom-3 z-[520] flex max-h-[82dvh] flex-col overflow-hidden backdrop-blur-xl md:inset-y-4 md:left-auto md:right-4 md:max-h-none md:w-[min(24rem,calc(100vw-2rem))]">
-      <header className="rl-modal-header flex items-start justify-between gap-3 px-4 py-3">
+      <header
+        className="rl-modal-header flex touch-pan-y items-start justify-between gap-3 px-4 py-3"
+        onPointerDown={beginPanelDrag}
+        onPointerMove={updatePanelDrag}
+        onPointerUp={endPanelDrag}
+        onPointerCancel={endPanelDrag}
+      >
         <div className="min-w-0 flex-1">
           <div className="flex min-w-0 items-start gap-2">
             <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-xl bg-teal-50 text-teal-700 ring-1 ring-teal-100">

--- a/src/components/map/scenicVisibilityLayer.ts
+++ b/src/components/map/scenicVisibilityLayer.ts
@@ -13,12 +13,23 @@ export type ScenicVisibilityMapItem = {
   distanceMeters?: number;
   selected: boolean;
   dimmed: boolean;
+  editable?: boolean;
+  onEdit?: (change: ScenicVisibilityEdit) => void;
+};
+
+export type ScenicVisibilityEdit = {
+  bearingDegrees?: number;
+  angleToleranceDegrees?: number;
+  distanceMeters?: number;
 };
 
 type ScenicLayerCache = L.LayerGroup & {
   _fan?: L.Polygon;
   _ray?: L.Polyline;
   _origin?: L.CircleMarker;
+  _targetHandle?: L.Marker;
+  _leftHandle?: L.Marker;
+  _rightHandle?: L.Marker;
 };
 
 const EARTH_RADIUS_METERS = 6371008.8;
@@ -33,6 +44,11 @@ function clamp(value: number, min: number, max: number): number {
 
 function normalizeDegrees(value: number): number {
   return ((value % 360) + 360) % 360;
+}
+
+function normalizeSignedDegrees(value: number): number {
+  const normalized = normalizeDegrees(value);
+  return normalized > 180 ? normalized - 360 : normalized;
 }
 
 function destinationLatLng(lat: number, lng: number, bearingDegrees: number, distanceMeters: number): L.LatLngTuple {
@@ -87,6 +103,16 @@ function rayLatLngs(item: ScenicVisibilityMapItem): L.LatLngExpression[] {
   ];
 }
 
+function editHandleLatLng(item: ScenicVisibilityMapItem, handle: "target" | "left" | "right"): L.LatLngTuple {
+  const tolerance = scenicToleranceDegrees(item);
+  const bearing = handle === "left"
+    ? item.bearingDegrees - tolerance
+    : handle === "right"
+      ? item.bearingDegrees + tolerance
+      : item.bearingDegrees;
+  return destinationLatLng(item.lat, item.lng, bearing, scenicDistanceMeters(item));
+}
+
 function statusColor(status: ScenicVisibilityStatus): string {
   switch (status) {
     case "visible":
@@ -133,6 +159,99 @@ function originStyle(item: ScenicVisibilityMapItem): L.CircleMarkerOptions {
   };
 }
 
+function editable(item: ScenicVisibilityMapItem): boolean {
+  return !!item.selected && !!item.editable && !!item.onEdit;
+}
+
+function handleIcon(handle: "target" | "left" | "right"): L.DivIcon {
+  const label = handle === "target" ? "B" : handle === "left" ? "L" : "R";
+  return L.divIcon({
+    className: `scenic-visibility-handle scenic-visibility-handle-${handle}`,
+    html: `<span>${label}</span>`,
+    iconSize: [22, 22],
+    iconAnchor: [11, 11],
+  });
+}
+
+function bearingFromOrigin(item: ScenicVisibilityMapItem, latLng: L.LatLng): number {
+  const fromLat = item.lat * Math.PI / 180;
+  const toLat = latLng.lat * Math.PI / 180;
+  const deltaLng = (latLng.lng - item.lng) * Math.PI / 180;
+  const y = Math.sin(deltaLng) * Math.cos(toLat);
+  const x = Math.cos(fromLat) * Math.sin(toLat)
+    - Math.sin(fromLat) * Math.cos(toLat) * Math.cos(deltaLng);
+  return normalizeDegrees(Math.atan2(y, x) * 180 / Math.PI);
+}
+
+function distanceFromOrigin(item: ScenicVisibilityMapItem, latLng: L.LatLng): number {
+  const lat1 = item.lat * Math.PI / 180;
+  const lat2 = latLng.lat * Math.PI / 180;
+  const dLat = lat2 - lat1;
+  const dLng = (latLng.lng - item.lng) * Math.PI / 180;
+  const a = Math.sin(dLat / 2) ** 2
+    + Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLng / 2) ** 2;
+  return EARTH_RADIUS_METERS * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+function updateEditHandle(
+  group: ScenicLayerCache,
+  item: ScenicVisibilityMapItem,
+  handle: "target" | "left" | "right",
+): void {
+  const property = handle === "target" ? "_targetHandle" : handle === "left" ? "_leftHandle" : "_rightHandle";
+  const current = group[property];
+  const latLng = editHandleLatLng(item, handle);
+  const onEdit = item.onEdit;
+
+  if (!editable(item) || !onEdit) {
+    if (current) {
+      group.removeLayer(current);
+      group[property] = undefined;
+    }
+    return;
+  }
+
+  const marker = current ?? L.marker(latLng, {
+    pane: "mileageEventsPane",
+    draggable: true,
+    interactive: true,
+    keyboard: false,
+    icon: handleIcon(handle),
+    zIndexOffset: 1300,
+  });
+  if (!current) {
+    group.addLayer(marker);
+    group[property] = marker;
+  } else {
+    marker.setLatLng(latLng);
+    marker.setIcon(handleIcon(handle));
+  }
+
+  marker.off("dragend");
+  marker.on("dragend", () => {
+    const nextLatLng = marker.getLatLng();
+    const nextBearing = bearingFromOrigin(item, nextLatLng);
+    const nextDistance = clamp(distanceFromOrigin(item, nextLatLng), 250, 5000);
+    if (handle === "target") {
+      onEdit({
+        bearingDegrees: nextBearing,
+        distanceMeters: nextDistance,
+      });
+      return;
+    }
+    onEdit({
+      angleToleranceDegrees: clamp(Math.abs(normalizeSignedDegrees(nextBearing - item.bearingDegrees)), 5, 90),
+      distanceMeters: nextDistance,
+    });
+  });
+}
+
+function updateEditHandles(group: ScenicLayerCache, item: ScenicVisibilityMapItem): void {
+  updateEditHandle(group, item, "target");
+  updateEditHandle(group, item, "left");
+  updateEditHandle(group, item, "right");
+}
+
 export function createScenicVisibilityLayer(item: ScenicVisibilityMapItem): L.Layer {
   const style = scenicLayerStyle(item);
   const fan = L.polygon(fanLatLngs(item), {
@@ -158,6 +277,7 @@ export function createScenicVisibilityLayer(item: ScenicVisibilityMapItem): L.La
   group._fan = fan;
   group._ray = ray;
   group._origin = origin;
+  updateEditHandles(group, item);
   return group;
 }
 
@@ -185,4 +305,5 @@ export function updateScenicVisibilityLayer(layer: L.Layer, item: ScenicVisibili
 
   group._origin?.setLatLng([item.lat, item.lng]);
   group._origin?.setStyle(originStyle(item));
+  updateEditHandles(group, item);
 }

--- a/src/components/mileage-events/EventComposer.tsx
+++ b/src/components/mileage-events/EventComposer.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { MapPinned, Navigation, Plus, Route, TrainFront } from "lucide-react";
+import { Compass, MapPinned, Navigation, Plus, Route, TrainFront } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useStore } from "../../store";
 import { useShallow } from "zustand/react/shallow";
-import type { UserEventV2 } from "../../rail-graph-v1/mileage-event.types";
+import type { ScenicFacing, UserEventV2 } from "../../rail-graph-v1/mileage-event.types";
 import { getTripRailGraphSnapshot } from "../../utils/railGraphTripPersistence";
 import { tripLineSummary, tripToProductSegments } from "../../utils/tripProductProjection";
 import {
@@ -18,12 +18,15 @@ import {
   tagsFromInput,
   tagsToInput,
   updateMileageEventFromDraft,
+  type ScenicViewpointDraft,
 } from "../../utils/mileageUserEvents";
 import { eventKindLabel, eventVisibilityLabel, mileageEventKinds, mileageEventVisibilities } from "./display";
 import { useMileageEventActions } from "./useMileageEventActions";
 import { requestMileageEventsMapCenter } from "../../utils/mileageEventUiBridge";
 
 type ComposerSource = "station" | "map" | "mileage" | "trip";
+
+const scenicFacingOptions: ScenicFacing[] = ["left", "right", "front", "back"];
 
 interface Props {
   event?: UserEventV2 | null;
@@ -90,6 +93,22 @@ export const EventComposer: React.FC<Props> = ({
   const [tagsInput, setTagsInput] = useState(event ? tagsToInput(event.tags) : defaultTagsInput);
   const [mediaUrl, setMediaUrl] = useState(String(event?.payload?.mediaUrl ?? defaultMediaUrl));
   const [linkedTripId, setLinkedTripId] = useState<string>(String(event?.payload?.tripId ?? defaultTripId ?? ""));
+  const [scenicFacing, setScenicFacing] = useState<ScenicFacing>(event?.payload?.viewpoint?.facing ?? "right");
+  const [scenicFacingTouched, setScenicFacingTouched] = useState(!!event?.payload?.viewpoint?.facing);
+  const [scenicBearing, setScenicBearing] = useState(
+    optionalNumberInput(event?.payload?.viewpoint?.targetBearingDegrees ?? event?.payload?.viewpoint?.constraint?.targetBearingDegrees),
+  );
+  const [scenicBearingTouched, setScenicBearingTouched] = useState(
+    event?.payload?.viewpoint?.targetBearingDegrees !== undefined || event?.payload?.viewpoint?.constraint?.targetBearingDegrees !== undefined,
+  );
+  const [scenicAngleTolerance, setScenicAngleTolerance] = useState(
+    optionalNumberInput(event?.payload?.viewpoint?.constraint?.angleToleranceDegrees ?? 30),
+  );
+  const [scenicAngleTouched, setScenicAngleTouched] = useState(!!event?.payload?.viewpoint?.constraint?.angleToleranceDegrees);
+  const [scenicDistanceMeters, setScenicDistanceMeters] = useState(
+    optionalNumberInput(event?.payload?.viewpoint?.constraint?.distanceMeters ?? 1500),
+  );
+  const [scenicDistanceTouched, setScenicDistanceTouched] = useState(!!event?.payload?.viewpoint?.constraint?.distanceMeters);
 
   useEffect(() => {
     if (event) {
@@ -101,6 +120,16 @@ export const EventComposer: React.FC<Props> = ({
       setMediaUrl(String(event.payload?.mediaUrl ?? ""));
       setLinkedTripId(String(event.payload?.tripId ?? ""));
       setDistanceKm((event.mileage.distanceMeters / 1000).toFixed(1));
+      setScenicFacing(event.payload?.viewpoint?.facing ?? "right");
+      setScenicFacingTouched(!!event.payload?.viewpoint?.facing);
+      setScenicBearing(optionalNumberInput(event.payload?.viewpoint?.targetBearingDegrees ?? event.payload?.viewpoint?.constraint?.targetBearingDegrees));
+      setScenicBearingTouched(
+        event.payload?.viewpoint?.targetBearingDegrees !== undefined || event.payload?.viewpoint?.constraint?.targetBearingDegrees !== undefined,
+      );
+      setScenicAngleTolerance(optionalNumberInput(event.payload?.viewpoint?.constraint?.angleToleranceDegrees ?? 30));
+      setScenicAngleTouched(!!event.payload?.viewpoint?.constraint?.angleToleranceDegrees);
+      setScenicDistanceMeters(optionalNumberInput(event.payload?.viewpoint?.constraint?.distanceMeters ?? 1500));
+      setScenicDistanceTouched(!!event.payload?.viewpoint?.constraint?.distanceMeters);
       if (eventLineKey) setLineKey(eventLineKey);
     }
   }, [event, eventLineKey]);
@@ -116,6 +145,14 @@ export const EventComposer: React.FC<Props> = ({
     setBody(defaultBody);
     setTagsInput(defaultTagsInput);
     setMediaUrl(defaultMediaUrl);
+    setScenicFacing("right");
+    setScenicFacingTouched(false);
+    setScenicBearing("");
+    setScenicBearingTouched(false);
+    setScenicAngleTolerance("30");
+    setScenicAngleTouched(false);
+    setScenicDistanceMeters("1500");
+    setScenicDistanceTouched(false);
   }, [defaultBody, defaultMediaUrl, defaultTagsInput, defaultTitle, event, resetKey]);
 
   useEffect(() => {
@@ -264,6 +301,19 @@ export const EventComposer: React.FC<Props> = ({
   };
   const createBlockedReason = sourceBlockedReason(source);
   const createDisabled = !event && !!createBlockedReason;
+  const scenicBearingNumber = parseOptionalNumber(scenicBearing);
+  const scenicAngleNumber = parseOptionalNumber(scenicAngleTolerance);
+  const scenicDistanceNumber = parseOptionalNumber(scenicDistanceMeters);
+  const scenicBearingValue = scenicBearingNumber ?? 0;
+  const scenicDraft = (): ScenicViewpointDraft | null | undefined => {
+    if (kind !== "scenic") return null;
+    return {
+      facing: event || scenicFacingTouched ? scenicFacing : undefined,
+      targetBearingDegrees: event || scenicBearingTouched ? scenicBearingNumber : undefined,
+      angleToleranceDegrees: event || scenicAngleTouched ? scenicAngleNumber : undefined,
+      distanceMeters: event || scenicDistanceTouched ? scenicDistanceNumber : undefined,
+    };
+  };
 
   const submit = () => {
     if (event) {
@@ -275,6 +325,7 @@ export const EventComposer: React.FC<Props> = ({
         tags: tagsFromInput(tagsInput),
         mediaUrl,
         tripId: linkedTripId || undefined,
+        scenicViewpoint: scenicDraft(),
       });
       updateEvent(updated);
       onSaved?.(updated);
@@ -289,6 +340,7 @@ export const EventComposer: React.FC<Props> = ({
       tags: tagsFromInput(tagsInput),
       mediaUrl,
       tripId: linkedTripId || undefined,
+      scenicViewpoint: scenicDraft(),
     };
 
     let created: UserEventV2 | null = null;
@@ -569,6 +621,117 @@ export const EventComposer: React.FC<Props> = ({
           </select>
         </label>
       </div>
+      {kind === "scenic" && (
+        <div className="rounded-md border border-sky-100 bg-sky-50/70 p-2">
+          <div className="mb-2 flex items-center gap-1.5 text-xs font-semibold text-sky-900">
+            <Compass size={14} />
+            <span>{t("mileageEvents.scenicViewpoint.title", "Scenic viewpoint")}</span>
+          </div>
+          <label className="block text-xs font-medium text-slate-600">
+            {t("mileageEvents.scenicViewpoint.facing", "Facing")}
+            <div className="mt-1 grid grid-cols-4 gap-1">
+              {scenicFacingOptions.map((option) => (
+                <button
+                  key={option}
+                  type="button"
+                  aria-pressed={scenicFacing === option}
+                  className={`rounded-md border px-2 py-1.5 text-[11px] font-semibold transition ${
+                    scenicFacing === option
+                      ? "border-sky-500 bg-white text-sky-700 shadow-sm"
+                      : "border-sky-100 bg-white/70 text-slate-500 hover:border-sky-200 hover:text-slate-800"
+                  }`}
+                  onClick={() => {
+                    setScenicFacing(option);
+                    setScenicFacingTouched(true);
+                  }}
+                >
+                  {t(`mileageEvents.scenicViewpoint.facingValue.${option}`, option)}
+                </button>
+              ))}
+            </div>
+          </label>
+          <div className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-3">
+            <label className="block text-xs font-medium text-slate-600">
+              {t("mileageEvents.scenicViewpoint.bearing", "Bearing")}
+              <input
+                className="mt-1 w-full rounded-md border border-slate-300 px-2 py-1.5 text-sm"
+                value={scenicBearing}
+                inputMode="decimal"
+                placeholder={t("mileageEvents.scenicViewpoint.auto", "Auto")}
+                onChange={(changeEvent) => {
+                  setScenicBearing(changeEvent.target.value);
+                  setScenicBearingTouched(true);
+                }}
+              />
+            </label>
+            <label className="block text-xs font-medium text-slate-600">
+              {t("mileageEvents.scenicViewpoint.angleTolerance", "Angle")}
+              <input
+                className="mt-1 w-full rounded-md border border-slate-300 px-2 py-1.5 text-sm"
+                value={scenicAngleTolerance}
+                inputMode="decimal"
+                onChange={(changeEvent) => {
+                  setScenicAngleTolerance(changeEvent.target.value);
+                  setScenicAngleTouched(true);
+                }}
+              />
+            </label>
+            <label className="block text-xs font-medium text-slate-600">
+              {t("mileageEvents.scenicViewpoint.distance", "Range")}
+              <input
+                className="mt-1 w-full rounded-md border border-slate-300 px-2 py-1.5 text-sm"
+                value={scenicDistanceMeters}
+                inputMode="decimal"
+                onChange={(changeEvent) => {
+                  setScenicDistanceMeters(changeEvent.target.value);
+                  setScenicDistanceTouched(true);
+                }}
+              />
+            </label>
+          </div>
+          <div className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-3">
+            <input
+              type="range"
+              min={0}
+              max={359}
+              step={1}
+              value={scenicBearingValue}
+              className="w-full accent-sky-600"
+              aria-label={t("mileageEvents.scenicViewpoint.bearing", "Bearing")}
+              onChange={(changeEvent) => {
+                setScenicBearing(changeEvent.target.value);
+                setScenicBearingTouched(true);
+              }}
+            />
+            <input
+              type="range"
+              min={5}
+              max={90}
+              step={1}
+              value={scenicAngleNumber ?? 30}
+              className="w-full accent-sky-600"
+              aria-label={t("mileageEvents.scenicViewpoint.angleTolerance", "Angle")}
+              onChange={(changeEvent) => {
+                setScenicAngleTolerance(changeEvent.target.value);
+                setScenicAngleTouched(true);
+              }}
+            />
+            <input
+              type="range"
+              min={250}
+              max={5000}
+              step={50}
+              value={scenicDistanceNumber ?? 1500}
+              className="w-full accent-sky-600"
+              aria-label={t("mileageEvents.scenicViewpoint.distance", "Range")}
+              onChange={(changeEvent) => {
+                setScenicDistanceMeters(changeEvent.target.value);
+                setScenicDistanceTouched(true);
+              }}
+            />
+          </div>
+        </div>
+      )}
       <input
         className="w-full rounded-md border border-slate-300 px-2 py-1.5 text-sm"
         placeholder={t("mileageEvents.tagsPlaceholder", "Tags, separated by comma")}
@@ -625,3 +788,13 @@ export const EventComposer: React.FC<Props> = ({
     </div>
   );
 };
+
+function optionalNumberInput(value: number | undefined): string {
+  return typeof value === "number" && Number.isFinite(value) ? String(Math.round(value * 10) / 10) : "";
+}
+
+function parseOptionalNumber(value: string): number | undefined {
+  if (!value.trim()) return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}

--- a/src/components/mileage-events/EventInspector.tsx
+++ b/src/components/mileage-events/EventInspector.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from "react";
 import {
+  Compass,
   Copy,
   Edit2,
   Eye,
@@ -242,6 +243,50 @@ export const EventInspector: React.FC<Props> = ({ event, onClose, onDeleted }) =
     );
   };
 
+  const renderScenicViewpoint = () => {
+    const viewpoint = event.payload?.viewpoint;
+    if (event.kind !== "scenic" && !viewpoint && !bound?.scenicVisibility) return null;
+    const visibility = bound?.scenicVisibility;
+    const status = visibility?.status ?? "unknown";
+    const bearing = visibility?.targetBearingDegrees ?? viewpoint?.targetBearingDegrees ?? viewpoint?.constraint?.targetBearingDegrees;
+    const angleTolerance = viewpoint?.constraint?.angleToleranceDegrees;
+    const distanceMeters = viewpoint?.constraint?.distanceMeters;
+    return (
+      <div className="rounded-md border border-sky-100 bg-sky-50/70 p-2 text-xs text-slate-600">
+        <div className="mb-2 flex items-center gap-1.5 font-semibold text-sky-900">
+          <Compass size={14} />
+          <span>{t("mileageEvents.scenicViewpoint.title", "Scenic viewpoint")}</span>
+        </div>
+        <dl className="grid grid-cols-2 gap-2">
+          <InfoTerm
+            label={t("mileageEvents.scenicViewpoint.status", "Status")}
+            value={t(`mileageEvents.scenicViewpoint.statusValue.${status}`, status)}
+          />
+          <InfoTerm
+            label={t("mileageEvents.scenicViewpoint.facing", "Facing")}
+            value={viewpoint?.facing ? t(`mileageEvents.scenicViewpoint.facingValue.${viewpoint.facing}`, viewpoint.facing) : t("mileageEvents.unknown", "Unknown")}
+          />
+          <InfoTerm
+            label={t("mileageEvents.scenicViewpoint.bearing", "Bearing")}
+            value={formatDegrees(bearing)}
+          />
+          <InfoTerm
+            label={t("mileageEvents.scenicViewpoint.angleTolerance", "Angle")}
+            value={formatDegrees(angleTolerance)}
+          />
+          <InfoTerm
+            label={t("mileageEvents.scenicViewpoint.distance", "Range")}
+            value={formatMeters(distanceMeters)}
+          />
+          <InfoTerm
+            label={t("mileageEvents.scenicViewpoint.confidence", "Confidence")}
+            value={visibility?.confidence !== undefined ? `${Math.round(visibility.confidence * 100)}%` : t("mileageEvents.unknown", "Unknown")}
+          />
+        </dl>
+      </div>
+    );
+  };
+
   if (editing) {
     return (
       <section className="rounded-md border border-slate-200 bg-white p-3">
@@ -299,6 +344,8 @@ export const EventInspector: React.FC<Props> = ({ event, onClose, onDeleted }) =
         </dl>
 
         {renderProjectionContext()}
+
+        {renderScenicViewpoint()}
 
         {projectionStatus && projectionStatus.code !== "projected" && (
           <ProjectionStatusNotice status={projectionStatus} />
@@ -455,3 +502,11 @@ const ActionButton: React.FC<{
     <span className="truncate">{label}</span>
   </button>
 );
+
+function formatDegrees(value: number | undefined): string {
+  return typeof value === "number" && Number.isFinite(value) ? `${Math.round(value)} deg` : "-";
+}
+
+function formatMeters(value: number | undefined): string {
+  return typeof value === "number" && Number.isFinite(value) ? `${Math.round(value)} m` : "-";
+}

--- a/src/index.css
+++ b/src/index.css
@@ -726,6 +726,42 @@
   --scenic-status-color: #7c3aed;
 }
 
+.scenic-visibility-handle {
+  width: 22px !important;
+  height: 22px !important;
+  border-radius: 999px;
+  border: 2px solid #fff;
+  background: #0369a1;
+  box-shadow:
+    0 8px 18px rgba(15,23,42,0.28),
+    0 0 0 1px rgba(2,132,199,0.5);
+  color: #fff;
+  cursor: grab;
+}
+
+.scenic-visibility-handle span {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.scenic-visibility-handle-left,
+.scenic-visibility-handle-right {
+  background: #0f766e;
+  box-shadow:
+    0 8px 18px rgba(15,23,42,0.26),
+    0 0 0 1px rgba(15,118,110,0.5);
+}
+
+.scenic-visibility-handle:active {
+  cursor: grabbing;
+}
+
 .mileage-event-marker.is-selected {
   transform: translateZ(0) scale(1.18);
   box-shadow:

--- a/src/utils/mileageUserEvents.ts
+++ b/src/utils/mileageUserEvents.ts
@@ -3,6 +3,8 @@ import type {
   MileagePlaceQuery,
   MileageProjectionContext,
   MileageRunPathLike,
+  ScenicFacing,
+  ScenicViewpointPayload,
   MileageUserEventKind,
   MileageUserEventVisibility,
   UserEventV2,
@@ -58,6 +60,14 @@ export interface MileageEventDraft {
   mediaUrl?: string;
   tripId?: string | number;
   lineKey?: string;
+  scenicViewpoint?: ScenicViewpointDraft | null;
+}
+
+export interface ScenicViewpointDraft {
+  facing?: ScenicFacing;
+  targetBearingDegrees?: number;
+  angleToleranceDegrees?: number;
+  distanceMeters?: number;
 }
 
 export interface MileageEventSearchFilters {
@@ -214,6 +224,7 @@ export function createMileageEventFromStation(args: {
   tags?: string[];
   mediaUrl?: string;
   tripId?: string | number;
+  scenicViewpoint?: ScenicViewpointDraft | null;
 }): UserEventV2 | null {
   const stationRef = stationRefForContext(args.lineContext, args.stationId);
   const station = args.lineContext.context.stationMileage[stationRef];
@@ -241,6 +252,7 @@ export function createMileageEventAtDistance(args: {
   tags?: string[];
   mediaUrl?: string;
   tripId?: string | number;
+  scenicViewpoint?: ScenicViewpointDraft | null;
 }): UserEventV2 {
   return createMileageEventAtResolvedDistance({
     lineContext: args.lineContext,
@@ -263,6 +275,7 @@ export function createMileageEventFromCoordinates(args: {
   tags?: string[];
   mediaUrl?: string;
   tripId?: string | number;
+  scenicViewpoint?: ScenicViewpointDraft | null;
 }): UserEventV2 | null {
   const resolved = resolvePlaceToMileage({ coordinates: args.coordinates }, args.lineContext.context);
   if (!resolved) return null;
@@ -291,6 +304,7 @@ export function createMileageEventFromPlace(args: {
   tags?: string[];
   mediaUrl?: string;
   tripId?: string | number;
+  scenicViewpoint?: ScenicViewpointDraft | null;
 }): UserEventV2 | null {
   const resolved = resolvePlaceToMileage(args.place, args.lineContext.context);
   if (!resolved) return null;
@@ -323,6 +337,7 @@ export function createMileageEventFromTripPosition(args: {
   visibility?: MileageUserEventVisibility;
   tags?: string[];
   mediaUrl?: string;
+  scenicViewpoint?: ScenicViewpointDraft | null;
 }): UserEventV2 | null {
   const railGraphTrip = getTripRailGraphSnapshot(args.trip)?.tripResult;
   if (railGraphTrip) {
@@ -377,6 +392,7 @@ export function createMileageEventFromTripPosition(args: {
 }
 
 export function updateMileageEventFromDraft(event: UserEventV2, draft: MileageEventDraft): UserEventV2 {
+  const nextKind = draft.kind ?? event.kind;
   const nextPayload = {
     ...(event.payload ?? {}),
     ...(draft.mediaUrl ? { mediaUrl: draft.mediaUrl.trim() } : {}),
@@ -384,9 +400,16 @@ export function updateMileageEventFromDraft(event: UserEventV2, draft: MileageEv
   };
   if (draft.mediaUrl !== undefined && draft.mediaUrl.trim() === "") delete nextPayload.mediaUrl;
   if (draft.tripId === null || draft.tripId === "") delete nextPayload.tripId;
+  if (nextKind === "scenic") {
+    const nextViewpoint = mergeScenicViewpointDraft(event.payload?.viewpoint, draft.scenicViewpoint);
+    if (nextViewpoint) nextPayload.viewpoint = nextViewpoint;
+    else delete nextPayload.viewpoint;
+  } else {
+    delete nextPayload.viewpoint;
+  }
   return {
     ...event,
-    kind: draft.kind ?? event.kind,
+    kind: nextKind,
     title: cleanTitle(draft.title ?? event.title),
     body: cleanOptional(draft.body) ?? undefined,
     visibility: draft.visibility ?? event.visibility,
@@ -920,15 +943,19 @@ function createMileageEventAtResolvedDistance(args: {
     ...(mediaUrl ? { mediaUrl } : {}),
     ...(tripId !== undefined && tripId !== "" ? { tripId } : {}),
   };
-  const viewpoint = kind === "scenic"
+  const inferredViewpoint = kind === "scenic"
     ? inferScenicViewpointPayload({
       context: args.lineContext.context,
       distanceMeters: args.distanceMeters,
       targetCoordinates: Array.isArray(basePayload.targetCoordinates)
         ? basePayload.targetCoordinates as [number, number]
         : undefined,
+      explicitFacing: args.draft.scenicViewpoint?.facing,
       source: args.lineContext.source === "rail_graph_runtime" ? "inferred_from_route" : "inferred_from_geojson",
     })
+    : undefined;
+  const viewpoint = kind === "scenic"
+    ? mergeScenicViewpointDraft(inferredViewpoint, args.draft.scenicViewpoint)
     : undefined;
   return {
     schemaVersion: "mileage-user-event-v1",
@@ -965,6 +992,82 @@ function cleanTitle(value: string | undefined): string {
 function cleanOptional(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
   return trimmed || undefined;
+}
+
+function mergeScenicViewpointDraft(
+  base: ScenicViewpointPayload | undefined,
+  draft: ScenicViewpointDraft | null | undefined,
+): ScenicViewpointPayload | undefined {
+  if (draft === null) return undefined;
+  const hasDraft =
+    draft !== undefined &&
+    (
+      draft.facing !== undefined ||
+      finiteNumber(draft.targetBearingDegrees) !== undefined ||
+      finiteNumber(draft.angleToleranceDegrees) !== undefined ||
+      finiteNumber(draft.distanceMeters) !== undefined
+    );
+  if (!base && !hasDraft) return undefined;
+
+  const facing = isScenicFacing(draft?.facing) ? draft.facing : base?.facing ?? "right";
+  const targetBearing = normalizeDegrees(
+    finiteNumber(draft?.targetBearingDegrees)
+      ?? finiteNumber(base?.targetBearingDegrees)
+      ?? finiteNumber(base?.constraint?.targetBearingDegrees)
+      ?? 90,
+  );
+  const angleTolerance = clampNumber(
+    finiteNumber(draft?.angleToleranceDegrees)
+      ?? finiteNumber(base?.constraint?.angleToleranceDegrees)
+      ?? 30,
+    5,
+    90,
+  );
+  const distanceMeters = clampNumber(
+    finiteNumber(draft?.distanceMeters)
+      ?? finiteNumber(base?.constraint?.distanceMeters)
+      ?? 1500,
+    250,
+    5000,
+  );
+  const visibleBearingRangeDegrees = bearingRangeFromCenter(targetBearing, angleTolerance);
+
+  return {
+    ...(base ?? {}),
+    facing,
+    targetBearingDegrees: targetBearing,
+    visibleBearingRangeDegrees,
+    constraint: {
+      ...(base?.constraint ?? {}),
+      targetBearingDegrees: targetBearing,
+      visibleBearingRangeDegrees,
+      angleToleranceDegrees: angleTolerance,
+      distanceMeters,
+    },
+    source: hasDraft ? "user_explicit" : base?.source ?? "inferred_from_route",
+    confidence: clampNumber(finiteNumber(base?.confidence) ?? (hasDraft ? 0.85 : 0.5), 0, 1),
+    diagnostics: base?.diagnostics ?? [],
+  };
+}
+
+function isScenicFacing(value: unknown): value is ScenicFacing {
+  return value === "left" || value === "right" || value === "front" || value === "back";
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function clampNumber(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function normalizeDegrees(value: number): number {
+  return ((value % 360) + 360) % 360;
+}
+
+function bearingRangeFromCenter(center: number, halfWidth: number): [number, number] {
+  return [normalizeDegrees(center - halfWidth), normalizeDegrees(center + halfWidth)];
 }
 
 function normalizeTripSegments(trip: Trip): TripSegment[] {


### PR DESCRIPTION
## Summary
- add explicit ScenicViewpoint draft/edit flow for mileage user events
- expose scenic facing/bearing/angle/range controls in Composer and Inspector with synced i18next keys
- add selected scenic MapView drag handles plus touch/pen drag behavior for the mileage panel edge handle
- update rail-graph main app docs to remove the now-completed drag/scenic gaps

## Verification
- npx tsc --noEmit
- npx vitest run src/__tests__/rail-graph-selection.test.ts src/__tests__/mileage-events-runtime-adapter.test.ts src/__tests__/rail-graph-trip-planner.test.ts src/__tests__/scenic-visibility-layer.test.ts
- git diff --check
- npx vite build
- npm --prefix blog run build

Note: pre-commit could not run because the local pre-commit command is not installed in this environment.