### PR TITLE
rail-graph: shrink mileage selection bridge

### DIFF
--- a/docs/rail-graph-main-app-flow.md
+++ b/docs/rail-graph-main-app-flow.md
@@ -175,6 +175,7 @@ Done:
 - `activeRailGraphSelection` is the shared non-persistent UI selection across Map route click, TripPage jump, GlobalSearch event jump, EventInspector map jump, and MileageEventsPanel.
 - Map event marker clicks preserve trip id, segment index, and route context when projection data is available.
 - `railGraphSelection.ts` centralizes bridge source conversion plus ProductTripSegment / event projection context / Map route item selection payloads, including legacy GeoJSON compatibility and explicit rail-graph source overrides.
+- `mileage-events:active-line` bridge state has been removed; active axes now derive from `activeRailGraphSelection`, while window events remain for Leaflet/DOM selection, open, fly-to, and map-point boundaries.
 - Scenic payload now flows through system events, user events, projection, and MapView rendering as a shared viewpoint/visibility contract instead of a plain event category.
 - MapView renders scenic visibility as a first-class Leaflet layer with status-colored fan/ray/origin geometry, plus distinct scenic marker styling.
 - Selected scenic user events expose explicit viewpoint controls in EventComposer/EventInspector and draggable MapView handles for bearing, angle tolerance, and range.
@@ -185,7 +186,6 @@ Done:
 
 Still incomplete:
 
-- Window bridge events and store `activeRailGraphSelection` still coexist; the bridge should shrink further to native Leaflet / DOM event boundaries.
 - Map selected route, selected event marker, dimmed routes, hover metadata, and touch metadata still need visual QA.
 - EventComposer and MileageEventsPanel need more narrow-screen visual QA and disabled-reason QA.
 - TripPage still needs replay/route visualization simplification and more top-level run summary polish.

--- a/docs/rail-graph-main-app-ui-flow.md
+++ b/docs/rail-graph-main-app-ui-flow.md
@@ -181,8 +181,8 @@ Current scenic implementation state:
 
 ### PR UI-1 - Active selection hardening
 
-- `railGraphSelection.ts` 已集中 bridge conversion、ProductTripSegment -> selection、event projection context -> selection、panel projection detail、open-detail route match 和 Map route item source override；MapContainer bridge handler 已减少 active axis 双写，active axis 主要从 store selection 派生。
-- Search、Inspector、TripPage 跳转与 Map route click 已直接写同一状态；后续继续把 window event 桥接限制在 Leaflet / DOM 边界。
+- `railGraphSelection.ts` 已集中 bridge conversion、ProductTripSegment -> selection、event projection context -> selection、panel projection detail、open-detail route match、active projection match 和 Map route item source override；MapContainer 不再通过 `mileage-events:active-line` bridge 写 active axis，active axis 从 store selection 派生。
+- Search、Inspector、TripPage 跳转、MileageEventsPanel event select 与 Map route/event click 已直接写同一状态；window event 桥接保留在 Leaflet / DOM 的 open/select/fly-to/map-point 边界。
 - Map event marker click 已补齐 trip / segment / route context，不再只传 eventId + lineKey。
 - PinEditor 已接入同一 selection，并通过纯 helper 覆盖 pin create -> legacy active axis -> panel map-source create payload。
 - PinEditor 的 snap 标题和事件轴提示使用可读 line label，不把 lineKey 作为主显示文本。

--- a/docs/rail-graph-v1-plan/15-main-app-data-and-interaction-flow.md
+++ b/docs/rail-graph-v1-plan/15-main-app-data-and-interaction-flow.md
@@ -143,7 +143,7 @@ legacy GeoJSON 不是临时兼容层，而是主应用仍需支持的数据源�
 | 维度 | 当前 | 目标 | 缺口 |
 |---|---:|---:|---|
 | 数据/投影接入 | 80% | 85% | legacy GeoJSON 已兼容，仍需 UI smoke 证明实际点击流。 |
-| selection / map wiring | 70% | 90% | shared selection 已覆盖 Map route click、Map event marker click、TripPage、Search、Inspector，仍需减少 window bridge 与 store selection 双写并补组件级 QA。 |
+| selection / map wiring | 70% | 90% | shared selection 已覆盖 Map route click、Map event marker click、TripPage、Search、Inspector；`mileage-events:active-line` 双写已移除，仍需补组件级 QA。 |
 | MapView 编辑体验 | 55% | 90% | 路线选择和面板打开已接上，仍需 route hover/touch、pin create、selected/dimmed 视觉 QA。 |
 | MileageEventsPanel | 65% | 90% | header/source cards 已改，仍需事件列表信息层级、窄屏与 disabled reason 打磨。 |
 | TripsPage | 70% | 90% | 已转向只读，仍需顶层 trip card 运行摘要和 replay 视觉精简。 |
@@ -157,7 +157,7 @@ legacy GeoJSON 不是临时兼容层，而是主应用仍需支持的数据源�
    - `railGraphSelection.ts` 统一 ProductTripSegment、event projection context、Map route item 与 bridge projection source 到 active selection 的转换。
    - Map event marker click 已携带 trip id、segment index、route item id，并在 bridge handler 中尽量还原为富 selection。
    - MileageEventsPanel open/select handler 已避免把同一路线 `kind="route"` selection 覆盖成普通 axis，从而保留 route-click create 所需 anchor。
-   - window bridge 只保留 Leaflet/native event 边界。
+   - window bridge 已移除 active axis 双写，只保留 Leaflet/native event 边界。
    - 已有 focused tests 覆盖 rail-graph/legacy product segment、event projection context、source override 和 bridge conversion；后续补 route click、TripPage event jump、Search/Inspector jump 的组件级行为测试。
 
 2. PR UI-B: MapView route and event editing loop

--- a/src/__tests__/rail-graph-selection.test.ts
+++ b/src/__tests__/rail-graph-selection.test.ts
@@ -7,6 +7,7 @@ import {
   isRouteSelection,
   openDetailMatchesActiveRouteSelection,
   productSegmentSelectionLineKey,
+  projectionDetailMatchesActiveSelection,
   projectionDetailFromRailGraphSelection,
   projectionDetailFromMileageEventsOpen,
   projectionSourceFromRailGraphSelection,
@@ -230,6 +231,62 @@ describe("rail graph active UI selection helpers", () => {
           tripSegmentIndex: 1,
         },
         selection,
+      ),
+    ).toBe(false);
+  });
+
+  it("recognizes route and event selections that already cover projection details", () => {
+    const routeSelection: RailGraphActiveSelection = {
+      state: "routeSelected",
+      kind: "route",
+      source: "rail_graph_snapshot",
+      lineKey: "rail-graph:pattern:local",
+      tripId: "trip:1",
+      tripSegmentIndex: 1,
+      routeItemId: "route:1",
+      updatedAt: 100,
+    };
+    const eventSelection: RailGraphActiveSelection = {
+      ...routeSelection,
+      state: "eventSelected",
+      kind: "event",
+      eventId: "event:1",
+    };
+
+    expect(
+      projectionDetailMatchesActiveSelection(
+        {
+          source: "rail_graph_runtime",
+          lineKey: "rail-graph:pattern:local",
+          tripId: "trip:1",
+          tripSegmentIndex: 1,
+          routeItemId: "route:1",
+        },
+        routeSelection,
+      ),
+    ).toBe(true);
+    expect(
+      projectionDetailMatchesActiveSelection(
+        {
+          source: "rail_graph_runtime",
+          lineKey: "rail-graph:pattern:local",
+          tripId: "trip:1",
+          tripSegmentIndex: 1,
+          routeItemId: "route:1",
+        },
+        eventSelection,
+        "event:1",
+      ),
+    ).toBe(true);
+    expect(
+      projectionDetailMatchesActiveSelection(
+        {
+          source: "legacy_app",
+          lineKey: "rail-graph:pattern:local",
+          tripId: "trip:1",
+          tripSegmentIndex: 1,
+        },
+        routeSelection,
       ),
     ).toBe(false);
   });

--- a/src/components/map/MapContainer.tsx
+++ b/src/components/map/MapContainer.tsx
@@ -29,17 +29,13 @@ import {
   mileageEventUiEvents,
   openMileageEventsPanel,
   selectMileageEventOnMap,
-  setActiveMileageLine,
   setMileageEventsMapPoint,
   type MileageEventSelectDetail,
-  type MileageEventsActiveLineDetail,
   type MileageEventsProjectionSource,
 } from "../../utils/mileageEventUiBridge";
 import {
   activeAxisFromRailGraphSelection,
   isEventSelection,
-  railGraphSelectionSourceFromProjection,
-  selectionFromActiveAxis,
   selectionFromMileageEventSelect,
   selectionFromProductSegment,
 } from "../../utils/railGraphSelection";
@@ -398,41 +394,6 @@ export const MapContainer: React.FC<Props> = ({
       if (detail.eventId) {
         setSelectedMileageEventId(detail.eventId);
       }
-      if (detail.lineKey || detail.source || detail.tripId !== undefined) {
-        const trip = detail.tripId !== undefined
-          ? trips.find((candidate) => String(candidate.id) === String(detail.tripId))
-          : null;
-        const productSegments = trip ? tripToProductSegments(trip, railwayData) : [];
-        const productSegment = typeof detail.tripSegmentIndex === "number"
-          ? productSegments[detail.tripSegmentIndex]
-          : undefined;
-        const selection = productSegment
-          ? selectionFromProductSegment({
-              kind: "event",
-              segment: productSegment,
-              source: detail.source ? railGraphSelectionSourceFromProjection(detail.source) : undefined,
-              lineKey: detail.lineKey ?? null,
-              tripId: detail.tripId,
-              tripSegmentIndex: detail.tripSegmentIndex,
-              routeItemId: detail.routeItemId,
-              eventId: detail.eventId,
-            })
-          : selectionFromMileageEventSelect(detail);
-        if (selection) {
-          setActiveRailGraphSelection(selection);
-        }
-      }
-    };
-
-    const handleActiveMileageLine = (event: Event) => {
-      const detail = customEventDetail<MileageEventsActiveLineDetail>(event);
-      if (!detail.lineKey && !detail.source) {
-        clearActiveRailGraphSelection();
-        return;
-      }
-      const selection = selectionFromActiveAxis(detail);
-      if (!selection) return;
-      setActiveRailGraphSelection(selection);
     };
 
     const handleFlyToLocation = (e: Event) => {
@@ -468,14 +429,12 @@ export const MapContainer: React.FC<Props> = ({
     window.addEventListener("map:create-temp-pin", handleCreateTempPin);
     window.addEventListener(mileageEventUiEvents.requestMapCenter, handleRequestMapCenter);
     window.addEventListener(mileageEventUiEvents.select, handleMileageEventSelect);
-    window.addEventListener(mileageEventUiEvents.activeLine, handleActiveMileageLine);
     window.addEventListener("map:fly-to-location", handleFlyToLocation);
       window.addEventListener("map:show-nearby-stations", handleShowNearbyStations);
     return () => {
       window.removeEventListener("map:create-temp-pin", handleCreateTempPin);
       window.removeEventListener(mileageEventUiEvents.requestMapCenter, handleRequestMapCenter);
       window.removeEventListener(mileageEventUiEvents.select, handleMileageEventSelect);
-      window.removeEventListener(mileageEventUiEvents.activeLine, handleActiveMileageLine);
       window.removeEventListener("map:fly-to-location", handleFlyToLocation);
         window.removeEventListener("map:show-nearby-stations", handleShowNearbyStations);
     };
@@ -1624,13 +1583,6 @@ export const MapContainer: React.FC<Props> = ({
       const projectionSource = item.source === "rail_graph" ? "rail_graph_runtime" : "legacy_app";
       const mapPoint = { lat: event.latlng.lat, lng: event.latlng.lng };
       const tripRatio = ratioAtRoutePoint(item, event.latlng);
-      setActiveMileageLine({
-        lineKey: item.lineKey ?? null,
-        source: projectionSource,
-        tripId: item.tripId,
-        tripSegmentIndex: item.segmentIndex,
-        routeItemId: item.id,
-      });
       const selection = selectionFromProductSegment({
         kind: "route",
         source: item.source === "rail_graph" ? "rail_graph_snapshot" : "legacy_geojson",
@@ -2051,6 +2003,8 @@ export const MapContainer: React.FC<Props> = ({
             item.selectionDetails[0];
           if (!detail) return;
           setSelectedMileageEventId(detail.eventId);
+          const selection = selectionFromMileageEventSelect(detail);
+          if (selection) setActiveRailGraphSelection(selection);
           selectMileageEventOnMap(detail);
         };
         layer.on("click", markerClickHandler);
@@ -2133,6 +2087,8 @@ export const MapContainer: React.FC<Props> = ({
             item.selectionDetails[0];
           if (!detail) return;
           setSelectedMileageEventId(detail.eventId);
+          const selection = selectionFromMileageEventSelect(detail);
+          if (selection) setActiveRailGraphSelection(selection);
           selectMileageEventOnMap(detail);
         };
         marker.on("click", markerClickHandler);

--- a/src/components/map/MileageEventsPanel.tsx
+++ b/src/components/map/MileageEventsPanel.tsx
@@ -36,7 +36,6 @@ import {
   mileageEventUiEvents,
   requestMileageEventsMapCenter,
   selectMileageEventOnMap,
-  setActiveMileageLine,
   type MileageEventSelectDetail,
   type MileageEventsComposerSource,
   type MileageEventsMapPointDetail,
@@ -51,10 +50,9 @@ import {
   openDetailMatchesActiveRouteSelection,
   projectionDetailFromRailGraphSelection,
   projectionDetailFromMileageEventsOpen,
-  railGraphSelectionSourceFromProjection,
-  selectionFromMileageEventSelect,
+  projectionDetailMatchesActiveSelection,
+  selectionFromActiveAxis,
   selectionFromMileageEventsOpen,
-  selectionFromProductSegment,
 } from "../../utils/railGraphSelection";
 
 export const MileageEventsPanel: React.FC = () => {
@@ -167,31 +165,9 @@ export const MileageEventsPanel: React.FC = () => {
         tripSegmentIndex: detail.tripSegmentIndex,
         routeItemId: detail.routeItemId,
       });
-      const trip = detail.tripId !== undefined
-        ? trips.find((candidate) => String(candidate.id) === String(detail.tripId))
-        : null;
-      const productSegments = trip ? tripToProductSegments(trip, railwayData) : [];
-      const productSegment = typeof detail.tripSegmentIndex === "number"
-        ? productSegments[detail.tripSegmentIndex]
-        : undefined;
-      const selection = productSegment
-        ? selectionFromProductSegment({
-            kind: "event",
-            segment: productSegment,
-            source: detail.source ? railGraphSelectionSourceFromProjection(detail.source) : undefined,
-            lineKey: detail.lineKey ?? null,
-            tripId: detail.tripId,
-            tripSegmentIndex: detail.tripSegmentIndex,
-            routeItemId: detail.routeItemId,
-            eventId: detail.eventId,
-          })
-        : selectionFromMileageEventSelect(detail);
-      if (selection) setActiveRailGraphSelection(selection);
       if (detail.lineKey && lineKeys.includes(detail.lineKey)) {
         setLineKey(detail.lineKey);
         setMode("line");
-      } else if (detail.source === "rail_graph_runtime") {
-        setActiveMileageLine({ lineKey: detail.lineKey ?? null, source: detail.source });
       }
     };
     const handleOpen = (event: Event) => {
@@ -376,28 +352,37 @@ export const MileageEventsPanel: React.FC = () => {
 
   useEffect(() => {
     if (!open) {
-      setActiveMileageLine({ lineKey: null });
       clearActiveRailGraphSelection();
       return;
     }
-    if (selectedProjection?.source === "rail_graph_runtime") {
-      setActiveMileageLine({
+    const axisDetail = selectedProjection?.source === "rail_graph_runtime"
+      ? {
         lineKey: selectedProjection.lineKey ?? null,
         source: selectedProjection.source,
         tripId: selectedProjection.tripId,
         tripSegmentIndex: selectedProjection.tripSegmentIndex,
         routeItemId: selectedProjection.routeItemId,
-      });
-      return;
-    }
-    setActiveMileageLine({
-      lineKey: lineContext ? effectiveLineKey : null,
-      source: selectedProjection?.source,
-      tripId: selectedProjection?.tripId,
-      tripSegmentIndex: selectedProjection?.tripSegmentIndex,
-      routeItemId: selectedProjection?.routeItemId,
-    });
-  }, [clearActiveRailGraphSelection, effectiveLineKey, lineContext, open, selectedProjection]);
+      }
+      : {
+        lineKey: lineContext ? effectiveLineKey : null,
+        source: selectedProjection?.source,
+        tripId: selectedProjection?.tripId,
+        tripSegmentIndex: selectedProjection?.tripSegmentIndex,
+        routeItemId: selectedProjection?.routeItemId,
+      };
+    if (projectionDetailMatchesActiveSelection(axisDetail, activeRailGraphSelection, selectedEventId)) return;
+    const selection = selectionFromActiveAxis(axisDetail);
+    if (selection) setActiveRailGraphSelection(selection);
+  }, [
+    activeRailGraphSelection,
+    clearActiveRailGraphSelection,
+    effectiveLineKey,
+    lineContext,
+    open,
+    selectedEventId,
+    selectedProjection,
+    setActiveRailGraphSelection,
+  ]);
 
   const selectEvent = (eventId: string, entry?: MileageEventListEntry) => {
     const inheritedProjection = selectedProjection ?? projectionDetailFromRailGraphSelection(activeRailGraphSelection);
@@ -412,6 +397,15 @@ export const MileageEventsPanel: React.FC = () => {
         : inheritedProjection;
     setSelectedEventId(eventId);
     setSelectedProjection(eventProjection ?? null);
+    const selection = selectionFromMileageEventsOpen({
+      eventId,
+      lineKey: eventProjection?.lineKey,
+      source: eventProjection?.source,
+      tripId: eventProjection?.tripId,
+      tripSegmentIndex: eventProjection?.tripSegmentIndex,
+      routeItemId: eventProjection?.routeItemId,
+    });
+    if (selection) setActiveRailGraphSelection(selection);
     selectMileageEventOnMap({
       eventId,
       lineKey: eventProjection?.lineKey,
@@ -426,6 +420,15 @@ export const MileageEventsPanel: React.FC = () => {
     const inheritedProjection = selectedProjection ?? projectionDetailFromRailGraphSelection(activeRailGraphSelection);
     if (composerDraft.source === "trip" && inheritedProjection?.source === "rail_graph_runtime") {
       setSelectedEventId(event.id);
+      const selection = selectionFromMileageEventsOpen({
+        eventId: event.id,
+        lineKey: inheritedProjection.lineKey,
+        source: inheritedProjection.source,
+        tripId: inheritedProjection.tripId,
+        tripSegmentIndex: inheritedProjection.tripSegmentIndex,
+        routeItemId: inheritedProjection.routeItemId,
+      });
+      if (selection) setActiveRailGraphSelection(selection);
       selectMileageEventOnMap({
         eventId: event.id,
         lineKey: inheritedProjection.lineKey,

--- a/src/utils/mileageEventUiBridge.ts
+++ b/src/utils/mileageEventUiBridge.ts
@@ -45,8 +45,6 @@ export interface MileageEventsActiveAxisDetail {
   routeItemId?: string;
 }
 
-export type MileageEventsActiveLineDetail = MileageEventsActiveAxisDetail;
-
 export interface MileageEventsMapPointDetail {
   lat: number;
   lng: number;
@@ -55,7 +53,6 @@ export interface MileageEventsMapPointDetail {
 export const mileageEventUiEvents = {
   open: "mileage-events:open",
   select: "mileage-event:select",
-  activeLine: "mileage-events:active-line",
   mapPoint: "mileage-events:map-point",
   requestMapCenter: "mileage-events:request-map-center",
 } as const;
@@ -74,10 +71,6 @@ export function openMileageEventsPanel(detail: MileageEventsOpenDetail) {
 
 export function selectMileageEventOnMap(detail: MileageEventSelectDetail) {
   window.dispatchEvent(new CustomEvent(mileageEventUiEvents.select, { detail }));
-}
-
-export function setActiveMileageLine(detail: MileageEventsActiveAxisDetail) {
-  window.dispatchEvent(new CustomEvent(mileageEventUiEvents.activeLine, { detail }));
 }
 
 export function setMileageEventsMapPoint(detail: MileageEventsMapPointDetail) {

--- a/src/utils/railGraphSelection.ts
+++ b/src/utils/railGraphSelection.ts
@@ -291,3 +291,22 @@ export function openDetailMatchesActiveRouteSelection(
     selection.tripSegmentIndex === detail.tripSegmentIndex
   );
 }
+
+export function projectionDetailMatchesActiveSelection(
+  detail: Partial<Omit<MileageEventsProjectionDetail, "lineKey">> & { lineKey?: string | null },
+  selection?: RailGraphActiveSelection | RailGraphSelectionDraft | null,
+  eventId?: string | null,
+): boolean {
+  if (!selection) return false;
+  if (eventId && isEventSelection(selection) && selection.eventId === eventId) return true;
+  const source = detail.source ? railGraphSelectionSourceFromProjection(detail.source) : undefined;
+  if (source && selection.source !== source) return false;
+  if (detail.routeItemId) return selection.routeItemId === detail.routeItemId;
+  if (detail.tripId !== undefined) {
+    return (
+      String(selection.tripId) === String(detail.tripId) &&
+      selection.tripSegmentIndex === detail.tripSegmentIndex
+    );
+  }
+  return !!detail.lineKey && selection.lineKey === detail.lineKey;
+}


### PR DESCRIPTION
## Summary
- removes the duplicated `mileage-events:active-line` bridge state from the map/panel selection path
- routes active-axis, route, event, and marker selection through the rail-graph selection store as the single source of truth
- updates the rail-graph flow docs to describe the reduced bridge surface and active-axis derivation

## Verification
- `npx tsc --noEmit`
- `npx vitest run src/__tests__/rail-graph-selection.test.ts src/__tests__/mileage-events-runtime-adapter.test.ts src/__tests__/rail-graph-trip-planner.test.ts src/__tests__/scenic-visibility-layer.test.ts`
- `git diff --check` (CRLF warnings only)
- `npx vite build` (existing warnings only)
- `npm --prefix blog run build` (existing warnings only)

Blocked locally:
- `pre-commit run --all-files` because `pre-commit` is not installed in this environment.