### PR TITLE
rail-graph: refine trip event center

### DIFF
--- a/docs/rail-graph-main-app-flow.md
+++ b/docs/rail-graph-main-app-flow.md
@@ -182,13 +182,14 @@ Done:
 - MileageEventsPanel closed state is a right-edge translucent handle that opens on pointer hover for mouse/pen, tap/click for touch, and drag-to-open/drag-to-close on touch/pen.
 - MileageEventsPanel header import/export controls are grouped under a compact action menu instead of two permanent header buttons.
 - TripPage event center has moved toward read-only overview and map jump instead of competing event editing/export tooling.
+- TripPage event center now renders through `TripEventCenter`, using `TripDetailModel.events` as the replay source so departure / arrival / transfer / scenic / user events share one read-only event model while stop/pass details stay out of the top replay.
 - Route metadata uses the shared badge visual language in React surfaces and Leaflet HTML.
 
 Still incomplete:
 
 - Map selected route, selected event marker, dimmed routes, hover metadata, and touch metadata still need visual QA.
 - EventComposer and MileageEventsPanel need more narrow-screen visual QA and disabled-reason QA.
-- TripPage still needs replay/route visualization simplification and more top-level run summary polish.
+- TripPage still needs browser-level desktop/mobile visual QA for the new event center and route slice layout.
 - Visual QA for mobile/desktop has not been completed.
 
 ## 8. PR Plan

--- a/docs/rail-graph-main-app-ui-flow.md
+++ b/docs/rail-graph-main-app-ui-flow.md
@@ -73,7 +73,7 @@ activeRailGraphSelection
 - Panel open / close 写入或清除 active axis。
 - `src/utils/railGraphSelection.ts` 统一 bridge projection source、product segment、event projection context 与 `activeRailGraphSelection` 的转换，避免 MapContainer / MileageEventsPanel / TripPage / Search / Inspector 各自手写 rail-graph vs legacy selection payload。
 - Create 模式会继承当前 route selection 的 `anchor`，把 rail-graph route 写为 trip-position source，把 legacy route 写为 map source。
-- TripPage replay / map editor jump、GlobalSearch event jump、EventInspector map jump 和 Map route click 会写入同一 selection，并尽量带上 `routeItemId`、segment index、label、color、pattern/service/direction metadata。
+- TripPage replay / MapView jump、GlobalSearch event jump、EventInspector map jump 和 Map route click 会写入同一 selection，并尽量带上 `routeItemId`、segment index、label、color、pattern/service/direction metadata。
 - PinEditor 从图钉创建用户事件前会写入 legacy GeoJSON active axis，并把 pin 坐标作为 create map source 传给 MileageEventsPanel。
 - MileageEventsPanel 在 rail-graph snapshot axis 下直接读取 rich projection 的当前 route events；GeoJSON place/time 查询不会误套到 snapshot route 上。
 
@@ -117,7 +117,7 @@ TripPage 的 event center 是只读概要：
 
 - 顶层展示 event count、snapshot / GeoJSON axis badge、运行摘要。
 - 展开后展示 line slices 与 mileage replay。
-- 主操作只有打开地图编辑器。
+- 主操作只有打开 MapView。
 - event row 可以跳转地图并选中事件。
 - 不提供 copy / JSON / MDX 事件工具；这些应放在地图事件面板或独立导出入口。
 
@@ -190,7 +190,7 @@ Current scenic implementation state:
 - 全局拖拽 overlay 的 line fallback 使用 `lineLabel()`，避免无 name 的拖拽项显示 raw lineKey。
 - StationSearchModal / GlobalSearchModal 的线路搜索结果使用同一 `lineLabel()` 口径；raw lineKey 仍可参与搜索匹配，但不作为结果主文案。
 - `lineSelectorBuilder` 也使用 `lineLabel()` 生成分类线路列表 displayName，LineSelector / StationSearchModal 分类页与搜索页保持一致。
-- 已增加 focused tests 覆盖 projection source 映射、event select、axis/open 转换、active axis 派生、panel projection detail、open-detail route match、rail-graph/legacy product segment selection、event projection context、Map route explicit source override 和 pin create bridge payload；EventComposer 已有 jsdom smoke 覆盖 source card 可见 target、disabled reason、map center 请求入口和 linked trip 文案；GlobalSearch 已有 jsdom smoke 覆盖 trip id 可搜索但不作为结果主文案；route serializer 覆盖导出失败时不把内部 line/station id 暴露为错误主文案，ExportRouteModal 会把这些错误映射到四语 i18next 文案。后续补组件级测试验证 route click / TripPage jump 的 DOM/Leaflet 行为。
+- 已增加 focused tests 覆盖 projection source 映射、event select、axis/open 转换、active axis 派生、panel projection detail、open-detail route match、rail-graph/legacy product segment selection、event projection context、Map route explicit source override 和 pin create bridge payload；EventComposer 已有 jsdom smoke 覆盖 source card 可见 target、disabled reason、map center 请求入口和 linked trip 文案；GlobalSearch 已有 jsdom smoke 覆盖 trip id 可搜索但不作为结果主文案；TripEventCenter 已有 jsdom smoke 覆盖 detail-model replay、scenic/user event 展示、raw trip/pattern ref 不作主文案、MapView jump 回调和旧 map-editor 文案移除；route serializer 覆盖导出失败时不把内部 line/station id 暴露为错误主文案，ExportRouteModal 会把这些错误映射到四语 i18next 文案。后续补组件级测试验证 route click / TripPage jump 的 DOM/Leaflet 行为。
 
 ### PR UI-2 - MileageEventsPanel redesign
 
@@ -210,6 +210,13 @@ Current scenic implementation state:
 
 - ExportRouteModal 已不再把 geoData 缺失作为 saved rail-graph snapshot 导出预览的前置阻断；如果 snapshot 自带 route geometry，可直接生成 route slice preview。
 - 导出失败错误按 missing line / missing station / disconnected route / empty trip / unknown failure 映射为 i18next 文案，未知异常不直接透传内部 id 或堆栈式信息到 UI。
+
+### PR UI-4.5 - TripPage event center polish
+
+- TripPage event center 已抽成 `TripEventCenter`，页面只负责传入 `TripDetailModel`、筛选后的 mileage user events 和 MapView selection 回调。
+- Replay 改由 `TripDetailModel.events` 驱动，默认展示 departure / arrival / transfer / scenic / user event；stop/pass 只作为 run summary 的统计/详情，不在主 replay 中重复刷屏。
+- 展开态移除了重复的 route segment 列表和 snapshot source 条，保留单一 run summary、单一 replay 和 `Open in MapView` 跳转；TripPage 不再显示 `Open map editor` 语义。
+- 四语 i18next 已补 `systemEvents`、`moreSegments`、`openMapView` key。
 
 ### PR UI-5 - Visual QA
 

--- a/docs/rail-graph-v1-plan/15-main-app-data-and-interaction-flow.md
+++ b/docs/rail-graph-v1-plan/15-main-app-data-and-interaction-flow.md
@@ -146,7 +146,7 @@ legacy GeoJSON 不是临时兼容层，而是主应用仍需支持的数据源�
 | selection / map wiring | 70% | 90% | shared selection 已覆盖 Map route click、Map event marker click、TripPage、Search、Inspector；`mileage-events:active-line` 双写已移除，仍需补组件级 QA。 |
 | MapView 编辑体验 | 55% | 90% | 路线选择和面板打开已接上，仍需 route hover/touch、pin create、selected/dimmed 视觉 QA。 |
 | MileageEventsPanel | 65% | 90% | header/source cards 已改，仍需事件列表信息层级、窄屏与 disabled reason 打磨。 |
-| TripsPage | 70% | 90% | 已转向只读，仍需顶层 trip card 运行摘要和 replay 视觉精简。 |
+| TripsPage | 80% | 90% | event center 已抽成 detail-model 驱动的只读 `TripEventCenter`，replay/重复 source 文案已精简；仍需浏览器级桌面/移动视觉 QA。 |
 | Search / Inspector / Export / TripEditor | 66% | 85% | map jump selection 已固化到 helper，仍需 raw ref、重复元数据和视觉一致性 QA。 |
 | visual system | 55% | 85% | React badge 与 Leaflet HTML badge 已有，仍需统一 event/pattern representative SVG/badge 组件和配色审计。 |
 
@@ -171,9 +171,9 @@ legacy GeoJSON 不是临时兼容层，而是主应用仍需支持的数据源�
    - legacy GeoJSON 和 saved snapshot 的 place/time/create 行为分开解释，避免 snapshot 误套 GeoJSON 查询。
 
 4. PR UI-D: TripsPage read-only replay polish
-   - trip card 顶层提升 pattern/service/direction/source/run summary。
-   - event center 只读，里程 replay 支持选中 event/route 后跳 MapView。
-   - 删除或移动残留事件管理/导出文案。
+   - trip card 顶层已保留 pattern/service/direction/source 摘要，expanded event center 使用 `TripEventCenter` 承担 run summary 和 replay。
+   - event center 只读，replay 改读 `TripDetailModel.events`，支持 user event 选中后跳 MapView。
+   - 已删除 `Open map editor` 语义，改为 `Open in MapView`；仍需浏览器级视觉 QA 检查 route slice 与 event center 在窄屏是否拥挤。
 
 5. PR UI-E: Shared visual asset and badge layer
    - 在一个 React 组件文件中集中 pattern type、run event、user event、source、geometry 的 SVG symbol / badge mapping。

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -216,7 +216,9 @@
       "departure": "Departure",
       "transfer": "Transfer",
       "arrival": "Arrival",
-      "openMapEditor": "Open map editor"
+      "systemEvents": "{{count}} system events",
+      "moreSegments": "+{{count}} segments",
+      "openMapView": "Open in MapView"
     },
     "eventFilters": {
       "title": "Trip event filters",

--- a/public/locales/ja-JP/translation.json
+++ b/public/locales/ja-JP/translation.json
@@ -216,7 +216,9 @@
       "departure": "出発",
       "transfer": "乗換",
       "arrival": "到着",
-      "openMapEditor": "マップ編集を開く"
+      "systemEvents": "{{count}} 件のシステムイベント",
+      "moreSegments": "+{{count}} 区間",
+      "openMapView": "MapView で開く"
     },
     "eventFilters": {
       "title": "旅程イベントフィルター",

--- a/public/locales/zh-CN/translation.json
+++ b/public/locales/zh-CN/translation.json
@@ -216,7 +216,9 @@
       "departure": "出发",
       "transfer": "换乘",
       "arrival": "到达",
-      "openMapEditor": "打开地图编辑器"
+      "systemEvents": "{{count}} 个系统事件",
+      "moreSegments": "+{{count}} 段",
+      "openMapView": "在地图中打开"
     },
     "eventFilters": {
       "title": "行程事件筛选",

--- a/public/locales/zh-TW/translation.json
+++ b/public/locales/zh-TW/translation.json
@@ -216,7 +216,9 @@
       "departure": "出發",
       "transfer": "換乘",
       "arrival": "抵達",
-      "openMapEditor": "打開地圖編輯器"
+      "systemEvents": "{{count}} 個系統事件",
+      "moreSegments": "+{{count}} 段",
+      "openMapView": "在地圖中打開"
     },
     "eventFilters": {
       "title": "行程事件篩選",

--- a/src/__tests__/trip-event-center-ui-smoke.test.ts
+++ b/src/__tests__/trip-event-center-ui-smoke.test.ts
@@ -1,0 +1,219 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React, { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createRoot, type Root } from "react-dom/client";
+import { TripEventCenter } from "../components/trips/TripEventCenter";
+import type { MileageEventListEntry } from "../components/mileage-events/EventList";
+import type { EntityRef } from "../rail-graph-v1/primitives";
+import type { TripDetailModel } from "../utils/railGraphTripDetailModel";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string | Record<string, unknown>, options?: Record<string, unknown>) => {
+      const template = typeof fallback === "string" ? fallback : _key;
+      const values = typeof fallback === "object" && fallback !== null ? fallback : options;
+      return template.replace(/\{\{(\w+)\}\}/g, (_match, key) => String(values?.[key] ?? ""));
+    },
+  }),
+}));
+
+describe("TripEventCenter rail-graph UI smoke", () => {
+  let host: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    host = document.createElement("div");
+    document.body.appendChild(host);
+    root = createRoot(host);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    host.remove();
+  });
+
+  it("renders a read-only detail-model replay without raw ids or map-editor wording", () => {
+    const onOpenMapView = vi.fn();
+    const onFocusEvent = vi.fn();
+    const entry = fixtureEntry();
+
+    act(() => {
+      root.render(React.createElement(TripEventCenter, {
+        detail: fixtureDetail(),
+        entries: [entry],
+        allEntryCount: 1,
+        filtered: false,
+        isExpanded: true,
+        selectedEventId: "event-photo",
+        onToggle: vi.fn(),
+        onOpenMapView,
+        onFocusEvent,
+      }));
+    });
+
+    expect(host.textContent).toContain("Rail graph run");
+    expect(host.textContent).toContain("Scenic");
+    expect(host.textContent).toContain("Scenic window");
+    expect(host.textContent).toContain("Photo stop");
+    expect(host.textContent).toContain("Open in MapView");
+    expect(host.textContent).not.toContain("internal-trip-id");
+    expect(host.textContent).not.toContain("manual:pattern:local");
+    expect(host.textContent).not.toContain("Open map editor");
+    expect(host.textContent).not.toContain("Passing station");
+
+    const openMapButton = Array.from(host.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Open in MapView"),
+    );
+    expect(openMapButton).toBeTruthy();
+    act(() => {
+      openMapButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(onOpenMapView).toHaveBeenCalledTimes(1);
+
+    const eventButton = Array.from(host.querySelectorAll("button")).reverse().find((button) =>
+      button.textContent?.includes("Photo stop"),
+    );
+    expect(eventButton).toBeTruthy();
+    act(() => {
+      eventButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(onFocusEvent).toHaveBeenCalledWith(entry);
+  });
+});
+
+function fixtureDetail(): TripDetailModel {
+  return {
+    kind: "rail_graph",
+    tripId: "internal-trip-id",
+    date: "2026-06-05",
+    overview: {
+      title: "Readable Alpha Line",
+      planUsed: "preset",
+      totalDistanceKm: 12.5,
+      totalTimeMinutes: 18,
+      eventTypeSummary: ["departure", "scenic", "user_event", "arrival"],
+      userEventCount: 1,
+      systemEventCount: 4,
+      segmentCount: 1,
+    },
+    segments: [{
+      id: "segment-1",
+      index: 0,
+      source: "rail_graph",
+      lineKey: "internal:line:alpha",
+      lineLabel: "Readable Alpha Line",
+      displayColor: "#10b981",
+      fromId: "internal:station:alpha",
+      fromName: "Alpha",
+      toId: "internal:station:beta",
+      toName: "Beta",
+      distanceKm: 12.5,
+      timeMinutes: 18,
+      systemRef: ref("internal:system"),
+      lineRef: ref("internal:line:alpha"),
+      patternRef: ref("manual:pattern:local"),
+      direction: "up",
+      serviceType: "Local",
+      viaStations: [],
+      viaStationCount: 2,
+      stopCount: 1,
+      passCount: 1,
+      systemEventCount: 4,
+      userEventCount: 1,
+      keyEvents: [],
+      geoSource: {
+        code: "rail_graph_snapshot",
+        hasGeometry: true,
+        hasFallback: false,
+        missingGeometryCount: 0,
+      },
+    }],
+    events: [{
+      id: "segment-1:departure",
+      source: "system",
+      type: "departure",
+      label: "Alpha",
+      segmentIndex: 0,
+      distanceMeters: 0,
+      stationName: "Alpha",
+      importance: "key",
+    }, {
+      id: "segment-1:scenic",
+      source: "system",
+      type: "scenic",
+      label: "Scenic window",
+      segmentIndex: 0,
+      distanceMeters: 4500,
+      importance: "key",
+    }, {
+      id: "user:event-photo",
+      source: "user",
+      type: "user_event",
+      label: "Photo stop",
+      segmentIndex: 0,
+      distanceMeters: 5000,
+      importance: "key",
+      userEventId: ref("event-photo"),
+    }, {
+      id: "segment-1:pass",
+      source: "system",
+      type: "pass",
+      label: "Passing station",
+      segmentIndex: 0,
+      distanceMeters: 6500,
+      importance: "detail",
+    }, {
+      id: "segment-1:arrival",
+      source: "system",
+      type: "arrival",
+      label: "Beta",
+      segmentIndex: 0,
+      distanceMeters: 12500,
+      stationName: "Beta",
+      importance: "key",
+    }],
+    geoSource: {
+      code: "rail_graph_snapshot",
+      hasGeometry: true,
+      hasFallback: false,
+      missingGeometryCount: 0,
+    },
+  };
+}
+
+function fixtureEntry(): MileageEventListEntry {
+  return {
+    bound: {
+      event: {
+        schemaVersion: "mileage-user-event-v1",
+        id: ref("event-photo"),
+        kind: "scenic",
+        title: "Photo stop",
+        body: "Left-side viewpoint",
+        visibility: "private",
+        tags: ["window"],
+        mileage: {
+          systemRef: ref("internal:system"),
+          lineRef: ref("internal:line:alpha"),
+          patternRef: ref("manual:pattern:local"),
+          direction: "up",
+          distanceMeters: 5000,
+        },
+        payload: {
+          tripId: "internal-trip-id",
+        },
+      },
+      distanceMetersFromRunStart: 5000,
+      orderIndex: 0,
+      timestampInference: "unknown",
+      diagnostics: [],
+    },
+    lineContext: null,
+  };
+}
+
+function ref(value: string): EntityRef {
+  return value as EntityRef;
+}

--- a/src/components/trips/TripEventCenter.tsx
+++ b/src/components/trips/TripEventCenter.tsx
@@ -1,0 +1,389 @@
+import React, { useMemo } from "react";
+import { ChevronDown, ChevronUp, MapPinned, Route, Tag } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { MileageEventListEntry } from "../mileage-events/EventList";
+import { eventKindLabel, eventLineLabel, eventStationLabel } from "../mileage-events/display";
+import {
+  RailGraphBadge,
+  RailGraphEventPill,
+  RailGraphRunBadges,
+  compactRailGraphRef,
+} from "../rail-graph/RailGraphBadges";
+import type { TripDetailEvent, TripDetailEventType, TripDetailModel } from "../../utils/railGraphTripDetailModel";
+import { formatKm } from "../../utils/mileageUserEvents";
+
+type TranslateFn = (key: string, fallback: string, options?: Record<string, unknown>) => string;
+
+interface TripEventCenterProps {
+  detail: TripDetailModel;
+  entries: MileageEventListEntry[];
+  allEntryCount: number;
+  isExpanded: boolean;
+  selectedEventId?: string | null;
+  filtered: boolean;
+  onToggle: () => void;
+  onOpenMapView: () => void;
+  onFocusEvent: (entry: MileageEventListEntry) => void;
+}
+
+export const TripEventCenter: React.FC<TripEventCenterProps> = ({
+  detail,
+  entries,
+  allEntryCount,
+  isExpanded,
+  selectedEventId,
+  filtered,
+  onToggle,
+  onOpenMapView,
+  onFocusEvent,
+}) => {
+  const { t } = useTranslation();
+  const entryByEventId = useMemo(
+    () => new Map(entries.map((entry) => [String(entry.bound.event.id), entry])),
+    [entries],
+  );
+  const replayEvents = useMemo(
+    () =>
+      detail.events
+        .filter((event) => event.importance === "key")
+        .sort((left, right) => {
+          const leftMeters = left.distanceMeters ?? Number.MAX_SAFE_INTEGER;
+          const rightMeters = right.distanceMeters ?? Number.MAX_SAFE_INTEGER;
+          return leftMeters - rightMeters || left.id.localeCompare(right.id);
+        }),
+    [detail.events],
+  );
+  const source = sourceBadge(detail, t);
+  const shownCount = filtered ? entries.length : allEntryCount;
+
+  return (
+    <div className="mt-3 border-t border-gray-100 pt-3" onClick={(event) => event.stopPropagation()}>
+      <button
+        type="button"
+        className="flex w-full items-center justify-between gap-3 rounded-md bg-slate-50 px-2 py-2 text-left hover:bg-slate-100"
+        onClick={onToggle}
+      >
+        <div className="min-w-0">
+          <div className="flex min-w-0 flex-wrap items-center gap-1.5 text-xs font-semibold text-slate-700">
+            <MapPinned size={14} className="shrink-0 text-emerald-600" />
+            <span>{t("tripsPage.eventCenter.summary", "{{count}} events", { count: allEntryCount })}</span>
+            <RailGraphBadge
+              icon={source.icon}
+              value={source.value}
+              tone={source.tone}
+              className="rounded bg-white"
+            />
+            {filtered && allEntryCount !== shownCount && (
+              <span className="rounded bg-emerald-100 px-1.5 py-0.5 text-[10px] text-emerald-700">
+                {t("tripsPage.eventCenter.filteredCount", "{{count}} shown", { count: shownCount })}
+              </span>
+            )}
+          </div>
+          <div className="mt-1 flex flex-wrap gap-1">
+            {entries.slice(0, 3).map((entry) => (
+              <span
+                key={String(entry.bound.event.id)}
+                className="inline-flex max-w-[14rem] items-center gap-1 rounded bg-white px-1 py-0.5"
+              >
+                <RailGraphBadge icon="distance" value={formatKm(entry.bound.distanceMetersFromRunStart)} tone="slate" className="rounded" />
+                <RailGraphEventPill
+                  type={entry.bound.event.kind}
+                  label={entry.bound.event.title}
+                  title={entry.bound.event.title}
+                  className="max-w-[9rem]"
+                />
+              </span>
+            ))}
+            {entries.length === 0 && (
+              <span className="text-[11px] text-slate-400">
+                {t("tripsPage.eventCenter.noEvents", "No mileage events")}
+              </span>
+            )}
+          </div>
+        </div>
+        {isExpanded ? <ChevronUp size={16} className="shrink-0 text-slate-400" /> : <ChevronDown size={16} className="shrink-0 text-slate-400" />}
+      </button>
+
+      {isExpanded && (
+        <div className="mt-3 rounded-md border border-slate-200 bg-white p-3">
+          <div className="flex flex-wrap items-center justify-between gap-2 border-b border-slate-100 pb-2">
+            <div className="flex min-w-0 flex-wrap items-center gap-1.5 text-[11px] text-slate-500">
+              <RailGraphBadge
+                icon={source.icon}
+                value={source.value}
+                tone={source.tone}
+                className="rounded bg-white"
+              />
+              <RailGraphBadge
+                icon="userEvent"
+                value={t("tripsPage.railGraph.userEvents", "{{count}} user events", { count: allEntryCount })}
+                tone="violet"
+                className="rounded bg-white"
+              />
+              <RailGraphBadge
+                icon="operation"
+                value={t("tripsPage.eventCenter.systemEvents", "{{count}} system events", { count: detail.overview.systemEventCount })}
+                tone="slate"
+                className="rounded bg-white"
+              />
+            </div>
+            <button
+              type="button"
+              className="inline-flex min-w-0 items-center gap-1 rounded-md bg-emerald-600 px-2 py-1.5 text-xs font-semibold text-white hover:bg-emerald-700"
+              onClick={onOpenMapView}
+              title={t("tripsPage.eventCenter.openMapView", "Open in MapView")}
+              aria-label={t("tripsPage.eventCenter.openMapView", "Open in MapView")}
+            >
+              <MapPinned size={13} className="shrink-0" />
+              <span className="truncate">{t("tripsPage.eventCenter.openMapView", "Open in MapView")}</span>
+            </button>
+          </div>
+
+          <TripRunSummary detail={detail} />
+
+          <div className="pt-3">
+            <div className="mb-2 flex flex-wrap items-center justify-between gap-2 px-1 text-xs">
+              <div className="font-semibold text-slate-700">
+                {t("tripsPage.eventCenter.replay", "Trip replay")}
+              </div>
+              <div className="text-[11px] text-slate-400">
+                {t("tripsPage.eventCenter.sortedByMileage", "Sorted by trip mileage")}
+              </div>
+            </div>
+            {replayEvents.length === 0 ? (
+              <div className="rounded-md border border-dashed border-slate-300 p-3 text-center text-xs text-slate-500">
+                {t("tripsPage.eventCenter.empty", "No events on this trip")}
+              </div>
+            ) : (
+              <div className="space-y-1.5">
+                {replayEvents.map((event) => (
+                  <ReplayRow
+                    key={event.id}
+                    detail={detail}
+                    event={event}
+                    entry={event.userEventId ? entryByEventId.get(String(event.userEventId)) : undefined}
+                    selected={!!event.userEventId && selectedEventId === event.userEventId}
+                    onFocusEvent={onFocusEvent}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const TripRunSummary: React.FC<{ detail: TripDetailModel }> = ({ detail }) => {
+  const { t } = useTranslation();
+  const firstSegment = detail.segments[0];
+  const visibleSegments = detail.segments.slice(0, 3);
+  const hiddenSegmentCount = Math.max(0, detail.segments.length - visibleSegments.length);
+  const keyEvents = detail.events.filter((event) => event.importance === "key").slice(0, 5);
+
+  return (
+    <div className="border-b border-slate-100 py-3">
+      <div className="flex min-w-0 flex-wrap items-center gap-2 text-[11px] text-slate-600">
+        <RailGraphBadge
+          icon={detail.kind === "rail_graph" ? "snapshot" : "legacy"}
+          value={detail.kind === "rail_graph" ? t("tripsPage.railGraph.run", "Rail graph run") : t("tripsPage.eventCenter.geoJsonAxis", "GeoJSON mileage axis")}
+          tone={detail.kind === "rail_graph" ? "emerald" : "slate"}
+          className="rounded"
+        />
+        <RailGraphRunBadges
+          meta={{
+            serviceType: firstSegment?.serviceType,
+            direction: firstSegment?.direction,
+            patternRef: firstSegment?.patternRef,
+          }}
+          badgeClassName="rounded"
+          patternClassName="max-w-[12rem]"
+        />
+        <RailGraphBadge icon="distance" value={formatDistanceKm(detail.overview.totalDistanceKm, t)} tone="slate" className="rounded" />
+        {detail.overview.totalTimeMinutes !== undefined && (
+          <RailGraphBadge icon="duration" value={formatMinutes(detail.overview.totalTimeMinutes, t)} tone="slate" className="rounded" />
+        )}
+      </div>
+
+      <div className="mt-2 grid gap-2 sm:grid-cols-2">
+        {visibleSegments.map((segment) => (
+          <div key={segment.id} className="grid min-w-0 grid-cols-[0.75rem_minmax(0,1fr)] gap-2 text-[11px] text-slate-600">
+            <span className="mt-1 h-2.5 w-2.5 rounded-full" style={{ backgroundColor: segment.displayColor || "#10b981" }} />
+            <div className="min-w-0">
+              <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+                <span className="truncate font-semibold text-slate-800" title={segment.lineLabel}>{segment.lineLabel}</span>
+                <RailGraphRunBadges
+                  meta={{ serviceType: segment.serviceType, direction: segment.direction }}
+                  badgeClassName="rounded bg-white"
+                />
+              </div>
+              <div className="truncate" title={`${segment.fromName} -> ${segment.toName}`}>
+                {segment.fromName} <span className="text-slate-300">-&gt;</span> {segment.toName}
+              </div>
+              <div className="mt-1 flex flex-wrap gap-1 text-[10px] text-slate-500">
+                <RailGraphBadge
+                  icon="stops"
+                  value={t("tripsPage.railGraph.stopPass", "{{stops}} stops / {{passes}} pass", { stops: segment.stopCount, passes: segment.passCount })}
+                  tone="slate"
+                  className="rounded bg-white"
+                />
+                <RailGraphBadge
+                  icon="via"
+                  value={t("tripsPage.railGraph.via", "{{count}} via", { count: segment.viaStationCount })}
+                  tone="slate"
+                  className="rounded bg-white"
+                />
+                {segment.patternRef && (
+                  <RailGraphBadge
+                    icon="pattern"
+                    label={t("mileageEvents.inspector.pattern", "Pattern")}
+                    value={compactRailGraphRef(segment.patternRef)}
+                    title={String(segment.patternRef)}
+                    tone="indigo"
+                    className="max-w-[12rem] rounded bg-white"
+                  />
+                )}
+              </div>
+            </div>
+          </div>
+        ))}
+        {hiddenSegmentCount > 0 && (
+          <div className="flex items-center rounded-md border border-dashed border-slate-200 px-2 py-1 text-[11px] font-semibold text-slate-500">
+            {t("tripsPage.eventCenter.moreSegments", "+{{count}} segments", { count: hiddenSegmentCount })}
+          </div>
+        )}
+      </div>
+
+      {keyEvents.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-1">
+          {keyEvents.map((event) => (
+            <RailGraphEventPill
+              key={event.id}
+              type={event.type}
+              label={`${detailEventTypeLabel(event.type, t)} - ${event.label}`}
+              title={event.label}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const ReplayRow: React.FC<{
+  detail: TripDetailModel;
+  event: TripDetailEvent;
+  entry?: MileageEventListEntry;
+  selected: boolean;
+  onFocusEvent: (entry: MileageEventListEntry) => void;
+}> = ({ detail, event, entry, selected, onFocusEvent }) => {
+  const { t } = useTranslation();
+  const segment = typeof event.segmentIndex === "number" ? detail.segments[event.segmentIndex] : undefined;
+  const line = entry ? eventLineLabel(entry.bound, entry.lineContext) : segment?.lineLabel;
+  const station = entry ? eventStationLabel(entry.bound, entry.lineContext) : event.stationName;
+  const eventTitle = entry?.bound.event.title ?? event.label;
+  const eventType = entry ? eventKindLabel(entry.bound.event.kind, t) : detailEventTypeLabel(event.type, t);
+  const eventBody = entry?.bound.event.body;
+  const eventTags = entry?.bound.event.tags?.slice(0, 3) ?? [];
+  const canFocusMap = !!entry;
+
+  const body = (
+    <>
+      <div className="flex min-w-0 items-center gap-2">
+        <RailGraphEventPill type={entry?.bound.event.kind ?? event.type} label={eventType} className="max-w-[8rem]" />
+        <span className="truncate font-semibold text-slate-800">{eventTitle}</span>
+        {canFocusMap && (
+          <span
+            className="ml-auto shrink-0 rounded p-1 text-slate-400 group-hover:bg-emerald-50 group-hover:text-emerald-700"
+            title={t("mileageEvents.action.viewMap", "View map")}
+            aria-label={t("mileageEvents.action.viewMap", "View map")}
+          >
+            <MapPinned size={13} />
+          </span>
+        )}
+      </div>
+      <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-slate-500">
+        {line && (
+          <span className="inline-flex max-w-[12rem] items-center gap-1 truncate">
+            <Route size={12} className="shrink-0 text-slate-400" />
+            <span className="truncate">{line}</span>
+          </span>
+        )}
+        {station && <span className="max-w-[10rem] truncate">{station}</span>}
+        {eventTags.map((tag) => (
+          <span key={tag} className="inline-flex items-center gap-1 rounded bg-slate-100 px-1.5 py-0.5 text-[10px] text-slate-600">
+            <Tag size={10} />
+            {tag}
+          </span>
+        ))}
+      </div>
+      {eventBody && <p className="mt-1 line-clamp-2 text-[11px] leading-relaxed text-slate-600">{eventBody}</p>}
+    </>
+  );
+
+  return (
+    <div className="grid grid-cols-[4.25rem_1rem_minmax(0,1fr)] gap-2 text-xs">
+      <div className="pt-2 text-right font-mono text-[11px] text-slate-500">
+        {event.distanceMeters !== undefined ? formatKm(event.distanceMeters) : "-"}
+      </div>
+      <div className="flex justify-center pt-2">
+        <span className={`h-2.5 w-2.5 rounded-full border-2 border-white shadow-sm ${selected ? "bg-emerald-600" : event.source === "user" ? "bg-violet-500" : "bg-slate-400"}`} />
+      </div>
+      {canFocusMap ? (
+        <button
+          type="button"
+          className={`group min-w-0 rounded-md border px-2 py-1.5 text-left transition ${
+            selected
+              ? "border-emerald-300 bg-emerald-50"
+              : "border-slate-200 bg-white hover:border-slate-300"
+          }`}
+          onClick={() => {
+            if (entry) onFocusEvent(entry);
+          }}
+        >
+          {body}
+        </button>
+      ) : (
+        <div className="min-w-0 rounded-md border border-slate-200 bg-white px-2 py-1.5 text-left">
+          {body}
+        </div>
+      )}
+    </div>
+  );
+};
+
+function sourceBadge(detail: TripDetailModel, t: TranslateFn) {
+  if (detail.kind === "rail_graph") {
+    return {
+      icon: "snapshot" as const,
+      tone: "emerald" as const,
+      value: t("tripsPage.eventCenter.snapshotAxis", "Saved snapshot axis"),
+    };
+  }
+  return {
+    icon: "legacy" as const,
+    tone: "slate" as const,
+    value: t("tripsPage.eventCenter.geoJsonAxis", "GeoJSON mileage axis"),
+  };
+}
+
+function detailEventTypeLabel(type: TripDetailEventType, t: TranslateFn) {
+  if (type === "departure") return t("tripsPage.railGraph.event.departure", "Departure");
+  if (type === "arrival") return t("tripsPage.railGraph.event.arrival", "Arrival");
+  if (type === "transfer") return t("tripsPage.railGraph.event.transfer", "Transfer");
+  if (type === "scenic") return t("tripsPage.railGraph.event.scenic", "Scenic");
+  if (type === "stop") return t("tripsPage.railGraph.event.stop", "Stop");
+  if (type === "pass") return t("tripsPage.railGraph.event.pass", "Pass");
+  if (type === "user_event") return t("tripsPage.railGraph.event.user", "User event");
+  if (type === "note" || type === "user_note") return t("tripsPage.railGraph.event.note", "Note");
+  return type;
+}
+
+function formatDistanceKm(km: number, t: TranslateFn) {
+  return t("tripsPage.railGraph.km", "{{value}} km", { value: Math.max(0, km).toFixed(1) });
+}
+
+function formatMinutes(minutes: number, t: TranslateFn) {
+  return t("tripsPage.railGraph.minutes", "{{count}} min", { count: Math.max(0, minutes || 0) });
+}

--- a/src/pages/TripsPage.tsx
+++ b/src/pages/TripsPage.tsx
@@ -12,8 +12,6 @@ import {
   ChevronUp,
   Eye,
   Filter,
-  MapPinned,
-  Route,
   Tag,
 } from "lucide-react";
 import { useStore } from "../store";
@@ -31,18 +29,16 @@ import {
 } from "../utils/networkDisplay";
 import type { MileageUserEventKind, MileageUserEventVisibility } from "../rail-graph-v1/mileage-event.types";
 import {
-  appStationRef,
   boundMileageEventForDisplay,
   buildRailGraphMileageLineContext,
-  buildAppMileageLineContext,
-  formatKm,
   lineLabel,
   projectEventsToTrip,
   searchMileageEvents,
   tagsFromInput,
 } from "../utils/mileageUserEvents";
 import type { MileageEventListEntry } from "../components/mileage-events/EventList";
-import { eventKindLabel, eventLineLabel, eventSourceLabel, eventStationLabel, eventVisibilityLabel, mileageEventKinds, mileageEventVisibilities } from "../components/mileage-events/display";
+import { eventKindLabel, eventVisibilityLabel, mileageEventKinds, mileageEventVisibilities } from "../components/mileage-events/display";
+import { TripEventCenter } from "../components/trips/TripEventCenter";
 import {
   tripLineSummary as productTripLineSummary,
   tripToProductSegments,
@@ -53,14 +49,10 @@ import {
 } from "../utils/railGraphSelection";
 import {
   buildTripDetailModel,
-  tripDetailKeyEvents,
-  type TripDetailModel,
 } from "../utils/railGraphTripDetailModel";
 import { mileageEventTripId, openMileageEventsPanel, selectMileageEventOnMap } from "../utils/mileageEventUiBridge";
 import {
   RailGraphBadge,
-  RailGraphEventPill,
-  RailGraphRunBadges,
   RailGraphSymbol,
   compactRailGraphRef,
   railGraphDirectionLabel as formatRailGraphDirection,
@@ -688,24 +680,6 @@ export const TripsPage: React.FC = () => {
     return formatRailGraphDirection(direction, t) || t("tripsPage.railGraph.unknown", "Unknown");
   };
 
-  const railGraphEventTypeLabel = (type: string) => {
-    if (type === "departure") return t("tripsPage.railGraph.event.departure", "Departure");
-    if (type === "arrival") return t("tripsPage.railGraph.event.arrival", "Arrival");
-    if (type === "transfer") return t("tripsPage.railGraph.event.transfer", "Transfer");
-    if (type === "scenic") return t("tripsPage.railGraph.event.scenic", "Scenic");
-    if (type === "stop") return t("tripsPage.railGraph.event.stop", "Stop");
-    if (type === "pass") return t("tripsPage.railGraph.event.pass", "Pass");
-    if (type === "user_event") return t("tripsPage.railGraph.event.user", "User event");
-    if (type === "note") return t("tripsPage.railGraph.event.note", "Note");
-    return type;
-  };
-
-  const formatDistanceKm = (km: number) =>
-    t("tripsPage.railGraph.km", "{{value}} km", { value: Math.max(0, km).toFixed(1) });
-
-  const formatMinutes = (minutes?: number) =>
-    t("tripsPage.railGraph.minutes", "{{count}} min", { count: Math.max(0, minutes || 0) });
-
   const railGraphChipValue = (values: Array<string | undefined>, maxItems = 2) => {
     const unique = Array.from(new Set(values.filter((value): value is string => !!value?.trim())));
     if (unique.length === 0) return "";
@@ -713,393 +687,25 @@ export const TripsPage: React.FC = () => {
     return unique.length > maxItems ? `${visible} +${unique.length - maxItems}` : visible;
   };
 
-  const renderRailGraphRunSummary = (detail: TripDetailModel, compact = false) => {
-    if (detail.kind !== "rail_graph") return null;
-    const keyEvents = tripDetailKeyEvents(detail, compact ? 3 : 5);
-    const firstSegment = detail.segments[0];
-    return (
-      <div className="mt-3 border-t border-emerald-100 pt-3">
-        <div className="flex flex-wrap items-center gap-2 text-[11px] text-slate-600">
-          <RailGraphBadge
-            icon="snapshot"
-            value={t("tripsPage.railGraph.run", "Rail graph run")}
-            tone="emerald"
-            className="rounded"
-          />
-          <RailGraphRunBadges
-            meta={{
-              serviceType: firstSegment?.serviceType,
-              direction: firstSegment?.direction,
-              patternRef: firstSegment?.patternRef,
-            }}
-            badgeClassName="rounded"
-            patternClassName="max-w-[12rem]"
-          />
-          <RailGraphBadge icon="distance" value={formatDistanceKm(detail.overview.totalDistanceKm)} tone="slate" className="rounded" />
-          {detail.overview.totalTimeMinutes !== undefined && (
-            <RailGraphBadge icon="duration" value={formatMinutes(detail.overview.totalTimeMinutes)} tone="slate" className="rounded" />
-          )}
-          <RailGraphBadge
-            icon="userEvent"
-            value={t("tripsPage.railGraph.userEvents", "{{count}} user events", { count: detail.overview.userEventCount })}
-            tone="violet"
-            className="rounded"
-          />
-        </div>
-
-        {!compact && (
-          <div className="mt-2 space-y-1.5">
-            {detail.segments.map((segment) => (
-              <div key={segment.id} className="grid grid-cols-[0.75rem_minmax(0,1fr)] gap-2 text-[11px] text-slate-600">
-                <span className="mt-1 h-2.5 w-2.5 rounded-full" style={{ backgroundColor: segment.displayColor || "#10b981" }} />
-                <div className="min-w-0">
-                  <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
-                    <span className="truncate font-semibold text-slate-800">{segment.lineLabel}</span>
-                    <RailGraphRunBadges
-                      meta={{ serviceType: segment.serviceType, direction: segment.direction }}
-                      badgeClassName="rounded"
-                    />
-                  </div>
-                  <div className="truncate">
-                    {segment.fromName} <span className="text-slate-300">→</span> {segment.toName}
-                  </div>
-                  <div className="mt-1 flex flex-wrap gap-1 text-[10px] text-slate-500">
-                    <RailGraphBadge
-                      icon="stops"
-                      value={t("tripsPage.railGraph.stopPass", "{{stops}} stops / {{passes}} pass", { stops: segment.stopCount, passes: segment.passCount })}
-                      tone="slate"
-                      className="rounded"
-                    />
-                    <RailGraphBadge
-                      icon="via"
-                      value={t("tripsPage.railGraph.via", "{{count}} via", { count: segment.viaStationCount })}
-                      tone="slate"
-                      className="rounded"
-                    />
-                    <RailGraphRunBadges
-                      meta={{ patternRef: segment.patternRef }}
-                      badgeClassName="rounded"
-                      patternClassName="max-w-[12rem]"
-                      showLabels
-                    />
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
-
-        {keyEvents.length > 0 && (
-          <div className="mt-2 flex flex-wrap gap-1">
-            {keyEvents.map((event) => (
-              <RailGraphEventPill
-                key={event.id}
-                type={event.type}
-                label={`${railGraphEventTypeLabel(event.type)} · ${event.label}`}
-                title={event.label}
-              />
-            ))}
-          </div>
-        )}
-      </div>
-    );
-  };
-
-  const tripReplayItems = (trip: (typeof trips)[number], entries: MileageEventListEntry[]) => {
-    const segments = tripToProductSegments(trip, railwayData);
-    const items: Array<
-      | {
-          id: string;
-          kind: "boundary";
-          role: "departure" | "transfer" | "arrival";
-          distanceMeters: number;
-          stationName: string;
-          lineName: string;
-        }
-      | {
-          id: string;
-          kind: "event";
-          distanceMeters: number;
-          entry: MileageEventListEntry;
-        }
-    > = [];
-    let cursor = 0;
-
-    segments.forEach((segment: any, index: number) => {
-      const lineName = segment.lineLabel || (segment.lineKey ? lineLabel(segment.lineKey) : "-");
-      const fromName = segment.fromName || t("mileageEvents.unknown", "Unknown");
-      const toName = segment.toName || t("mileageEvents.unknown", "Unknown");
-      const lineContext = segment.lineKey ? buildAppMileageLineContext(railwayData, segment.lineKey) : null;
-      const fromMileage = lineContext?.context.stationMileage[appStationRef(segment.lineKey, segment.fromId)];
-      const toMileage = lineContext?.context.stationMileage[appStationRef(segment.lineKey, segment.toId)];
-      const segmentMeters = fromMileage && toMileage
-        ? Math.abs(toMileage.distanceMeters - fromMileage.distanceMeters)
-        : Math.round((segment.distanceKm || 0) * 1000);
-
-      items.push({
-        id: `boundary:${index}:start`,
-        kind: "boundary",
-        role: index === 0 ? "departure" : "transfer",
-        distanceMeters: cursor,
-        stationName: fromName,
-        lineName,
-      });
-
-      cursor += segmentMeters;
-
-      if (index === segments.length - 1) {
-        items.push({
-          id: `boundary:${index}:end`,
-          kind: "boundary",
-          role: "arrival",
-          distanceMeters: cursor,
-          stationName: toName,
-          lineName,
-        });
-      }
-    });
-
-    entries.forEach((entry) => {
-      items.push({
-        id: `event:${entry.bound.event.id}`,
-        kind: "event",
-        distanceMeters: entry.bound.distanceMetersFromRunStart,
-        entry,
-      });
-    });
-
-    const order = { departure: 0, transfer: 1, event: 2, arrival: 3 };
-    return items.sort((left, right) => {
-      const leftOrder = left.kind === "boundary" ? order[left.role] : order.event;
-      const rightOrder = right.kind === "boundary" ? order[right.role] : order.event;
-      return left.distanceMeters - right.distanceMeters || leftOrder - rightOrder || left.id.localeCompare(right.id);
-    });
-  };
-
-  const boundaryRoleLabel = (role: "departure" | "transfer" | "arrival") => {
-    if (role === "departure") return t("tripsPage.eventCenter.departure", "Departure");
-    if (role === "arrival") return t("tripsPage.eventCenter.arrival", "Arrival");
-    return t("tripsPage.eventCenter.transfer", "Transfer");
-  };
-
   const renderTripEventCenter = (trip: (typeof trips)[number]) => {
     const tripId = String(trip.id);
     const entries = tripEventEntries(trip);
     const allEntries = tripEventEntriesMap.get(tripId) ?? [];
-    const replayItems = tripReplayItems(trip, entries);
     const detail = buildTripDetailModel({ trip, railwayData, userEvents: mileageUserEvents });
     const isExpanded = expandedTripId === tripId;
 
     return (
-      <div className="mt-3 border-t border-gray-100 pt-3" onClick={(event) => event.stopPropagation()}>
-        <button
-          type="button"
-          className="flex w-full items-center justify-between gap-3 rounded-md bg-slate-50 px-2 py-2 text-left hover:bg-slate-100"
-          onClick={() => setExpandedTripId(isExpanded ? null : tripId)}
-        >
-          <div className="min-w-0">
-            <div className="flex items-center gap-1.5 text-xs font-semibold text-slate-700">
-              <MapPinned size={14} className="text-emerald-600" />
-              {t("tripsPage.eventCenter.summary", "{{count}} events", { count: allEntries.length })}
-              <RailGraphBadge
-                icon={detail.kind === "rail_graph" ? "snapshot" : "legacy"}
-                value={
-                  detail.kind === "rail_graph"
-                    ? t("tripsPage.eventCenter.snapshotAxis", "Saved snapshot axis")
-                    : t("tripsPage.eventCenter.geoJsonAxis", "GeoJSON mileage axis")
-                }
-                tone={detail.kind === "rail_graph" ? "emerald" : "slate"}
-                className="rounded bg-white"
-              />
-              {filteredEventIds && allEntries.length !== entries.length && (
-                <span className="rounded bg-emerald-100 px-1.5 py-0.5 text-[10px] text-emerald-700">
-                  {t("tripsPage.eventCenter.filteredCount", "{{count}} shown", { count: entries.length })}
-                </span>
-              )}
-            </div>
-            <div className="mt-1 flex flex-wrap gap-1">
-              {entries.slice(0, 3).map((entry) => (
-                <span
-                  key={entry.bound.event.id}
-                  className="inline-flex max-w-[14rem] items-center gap-1 rounded bg-white px-1 py-0.5"
-                >
-                  <RailGraphBadge icon="distance" value={formatKm(entry.bound.distanceMetersFromRunStart)} tone="slate" className="rounded" />
-                  <RailGraphEventPill
-                    type={entry.bound.event.kind}
-                    label={entry.bound.event.title}
-                    title={entry.bound.event.title}
-                    className="max-w-[9rem]"
-                  />
-                </span>
-              ))}
-              {entries.length === 0 && (
-                <span className="text-[11px] text-slate-400">
-                  {t("tripsPage.eventCenter.noEvents", "No mileage events")}
-                </span>
-              )}
-            </div>
-          </div>
-          {isExpanded ? <ChevronUp size={16} className="shrink-0 text-slate-400" /> : <ChevronDown size={16} className="shrink-0 text-slate-400" />}
-        </button>
-
-        {isExpanded && (
-          <div className="mt-3 space-y-3 rounded-md border border-slate-200 bg-white p-3">
-            {renderRailGraphRunSummary(detail)}
-
-            <div className="space-y-1">
-              {tripToProductSegments(trip, railwayData).map((segment: any, index: number) => {
-                const from = segment.fromName || t("mileageEvents.unknown", "Unknown");
-                const to = segment.toName || t("mileageEvents.unknown", "Unknown");
-                const lineName = segment.lineLabel || (segment.lineKey ? lineLabel(segment.lineKey) : "-");
-                return (
-                  <div key={`${segment.lineKey}_${segment.fromId}_${segment.toId}_${index}`} className="grid grid-cols-[0.5rem_minmax(0,1fr)] gap-2 text-[11px] text-slate-500">
-                    <span className="mt-1.5 h-2 w-2 rounded-full bg-emerald-500" />
-                    <div className="min-w-0">
-                      <div className="truncate font-semibold text-slate-600" title={lineName}>{lineName}</div>
-                      <div className="truncate" title={`${from} -> ${to}`}>
-                        {from} <span className="text-slate-300">→</span> {to}
-                      </div>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-
-            <div className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-slate-200 bg-slate-50/70 p-2">
-              <div className="flex min-w-0 flex-wrap items-center gap-1.5 text-[11px] text-slate-500">
-                <RailGraphBadge
-                  icon={detail.kind === "rail_graph" ? "snapshot" : "legacy"}
-                  value={
-                    detail.kind === "rail_graph"
-                      ? t("tripsPage.eventCenter.snapshotAxis", "Saved snapshot axis")
-                      : t("tripsPage.eventCenter.geoJsonAxis", "GeoJSON mileage axis")
-                  }
-                  tone={detail.kind === "rail_graph" ? "emerald" : "slate"}
-                  className="rounded bg-white"
-                />
-              </div>
-              <button
-                type="button"
-                className="inline-flex items-center gap-1 rounded-md bg-emerald-600 px-2 py-1.5 text-xs font-semibold text-white hover:bg-emerald-700"
-                onClick={() => openTripEventMapEditor(trip)}
-                title={t("tripsPage.eventCenter.openMapEditor", "Open map editor")}
-                aria-label={t("tripsPage.eventCenter.openMapEditor", "Open map editor")}
-              >
-                <MapPinned size={13} />
-                {t("tripsPage.eventCenter.openMapEditor", "Open map editor")}
-              </button>
-            </div>
-
-            <div className="rounded-md border border-slate-200 bg-slate-50/60 p-2">
-              <div className="mb-2 flex flex-wrap items-center justify-between gap-2 px-1 text-xs">
-                <div className="font-semibold text-slate-700">
-                  {t("tripsPage.eventCenter.replay", "Trip replay")}
-                </div>
-                <div className="text-[11px] text-slate-400">
-                  {t("tripsPage.eventCenter.sortedByMileage", "Sorted by trip mileage")}
-                </div>
-              </div>
-              <div className="space-y-1.5">
-                {replayItems.map((item) => {
-                  if (item.kind === "boundary") {
-                    return (
-                      <div key={item.id} className="grid grid-cols-[4.5rem_1rem_minmax(0,1fr)] gap-2 text-xs">
-                        <div className="pt-1 text-right font-mono text-[11px] text-slate-400">
-                          {formatKm(item.distanceMeters)}
-                        </div>
-                        <div className="flex justify-center pt-1">
-                          <span className="h-2.5 w-2.5 rounded-full border-2 border-white bg-emerald-500 shadow-sm" />
-                        </div>
-                        <div className="rounded-md border border-slate-200 bg-white px-2 py-1.5">
-                          <div className="flex min-w-0 items-center gap-2">
-                            <span className="shrink-0 rounded bg-emerald-50 px-1.5 py-0.5 text-[10px] font-semibold text-emerald-700">
-                              {boundaryRoleLabel(item.role)}
-                            </span>
-                            <span className="truncate font-semibold text-slate-700">{item.stationName}</span>
-                          </div>
-                          <div className="mt-0.5 truncate text-[11px] text-slate-400">{item.lineName}</div>
-                        </div>
-                      </div>
-                    );
-                  }
-
-                  const event = item.entry.bound.event;
-                  const selected = selectedTripEventId === event.id;
-                  const eventLine = eventLineLabel(item.entry.bound, item.entry.lineContext);
-                  const eventStation = eventStationLabel(item.entry.bound, item.entry.lineContext);
-                  const sourceIsRailGraph = item.entry.lineContext?.source === "rail_graph_runtime";
-                  return (
-                    <div key={item.id} className="grid grid-cols-[4.5rem_1rem_minmax(0,1fr)] gap-2 text-xs">
-                      <div className="pt-2 text-right font-mono text-[11px] text-slate-500">
-                        {formatKm(item.distanceMeters)}
-                      </div>
-                      <div className="flex justify-center pt-2">
-                        <span className={`h-2.5 w-2.5 rounded-full border-2 border-white shadow-sm ${selected ? "bg-emerald-600" : "bg-slate-400"}`} />
-                      </div>
-                      <div
-                        role="button"
-                        tabIndex={0}
-                        className={`min-w-0 rounded-md border px-2 py-1.5 text-left transition ${
-                          selected
-                            ? "border-emerald-300 bg-emerald-50"
-                            : "border-slate-200 bg-white hover:border-slate-300"
-                        }`}
-                        onClick={() => focusTripEventOnMap(trip, item.entry)}
-                        onKeyDown={(keyEvent) => {
-                          if (keyEvent.key === "Enter" || keyEvent.key === " ") {
-                            keyEvent.preventDefault();
-                            focusTripEventOnMap(trip, item.entry);
-                          }
-                        }}
-                      >
-                        <div className="flex min-w-0 items-center gap-2">
-                          <RailGraphEventPill type={event.kind} label={eventKindLabel(event.kind, t)} className="max-w-[8rem]" />
-                          <span className="truncate font-semibold text-slate-800">{event.title}</span>
-                          <button
-                            type="button"
-                            className="ml-auto shrink-0 rounded p-1 text-slate-400 hover:bg-emerald-50 hover:text-emerald-700"
-                            onClick={(clickEvent) => {
-                              clickEvent.stopPropagation();
-                              focusTripEventOnMap(trip, item.entry);
-                            }}
-                            title={t("mileageEvents.action.viewMap", "View map")}
-                            aria-label={t("mileageEvents.action.viewMap", "View map")}
-                          >
-                            <MapPinned size={13} />
-                          </button>
-                        </div>
-                        <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-slate-500">
-                          <RailGraphBadge
-                            icon={sourceIsRailGraph ? "snapshot" : "legacy"}
-                            value={eventSourceLabel(item.entry.lineContext, t)}
-                            tone={sourceIsRailGraph ? "emerald" : "slate"}
-                            className="rounded"
-                          />
-                          {eventLine && (
-                            <span className="inline-flex max-w-[12rem] items-center gap-1 truncate">
-                              <Route size={12} className="shrink-0 text-slate-400" />
-                              <span className="truncate">{eventLine}</span>
-                            </span>
-                          )}
-                          {eventStation && <span className="max-w-[10rem] truncate">{eventStation}</span>}
-                          {event.tags?.slice(0, 3).map((tag) => (
-                            <span key={tag} className="inline-flex items-center gap-1 rounded bg-slate-100 px-1.5 py-0.5 text-[10px] text-slate-600">
-                              <Tag size={10} />
-                              {tag}
-                            </span>
-                          ))}
-                        </div>
-                        {event.body && <p className="mt-1 line-clamp-2 text-[11px] leading-relaxed text-slate-600">{event.body}</p>}
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
-
-          </div>
-        )}
-      </div>
+      <TripEventCenter
+        detail={detail}
+        entries={entries}
+        allEntryCount={allEntries.length}
+        filtered={!!filteredEventIds}
+        isExpanded={isExpanded}
+        selectedEventId={selectedTripEventId}
+        onToggle={() => setExpandedTripId(isExpanded ? null : tripId)}
+        onOpenMapView={() => openTripEventMapEditor(trip)}
+        onFocusEvent={(entry) => focusTripEventOnMap(trip, entry)}
+      />
     );
   };
 
@@ -1608,7 +1214,6 @@ export const TripsPage: React.FC = () => {
           </div>
           <RouteSlice segments={segments} />
         </div>
-        {renderRailGraphRunSummary(detail, true)}
         {trip.memo && (
           <div className="text-xs text-gray-500 bg-gray-50 p-2 rounded mt-3">
             {trip.memo}


### PR DESCRIPTION
## Summary
- extracts TripPage mileage event center into a dedicated `TripEventCenter` presentation component
- drives TripPage replay from `TripDetailModel.events` so departure/arrival/transfer/scenic/user events share one read-only model while stop/pass stay out of the top replay
- removes duplicate expanded source/segment blocks and replaces the old `Open map editor` wording with `Open in MapView`
- syncs four locale files and updates the rail-graph main-app flow docs/status

## Verification
- `npx tsc --noEmit`
- `npx vitest run src/__tests__/trip-event-center-ui-smoke.test.ts src/__tests__/rail-graph-trip-detail-model.test.ts src/__tests__/global-search-ui-smoke.test.ts src/__tests__/event-composer-ui-smoke.test.ts`
- `git diff --check` / `git diff --cached --check` (CRLF warnings only before staging; staged check clean)
- `npm run check:release-content` (passes; existing warning about v0.52 missing en/ja-jp/zh-tw blog pages)
- `npx vite build` (passes; existing Browserslist/chunk/dynamic-import warnings)
- `npm --prefix blog run build` (passes; existing Browserslist/chunk warnings)

Blocked locally:
- `pre-commit run --all-files` because `pre-commit` is not installed in this environment.