### PR TITLE
⚡ Bolt: [performance improvement] Replace turf.length with calcPolylineDist to eliminate object allocation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-04-15 - [Avoid O(N log N) Sorting on Massive Geographical Collections]
 **Learning:** In spatial queries like `findNearbyStations` where we scan `railwayData` containing thousands of stations to find the top K nearest points, allocating all elements to an array and running `Array.prototype.sort()` results in massive temporary object allocation and $O(N \log N)$ execution time (taking ~8.5ms in benchmarks).
 **Action:** Replace full array sorts with a bounded Top-K array using a simple $O(K)$ insertion sort during the $O(N)$ iteration phase. This brings the time complexity effectively down to $O(N)$, speeding up operations by ~36x (taking ~0.24ms). Remember to apply a final sort if total elements found are less than $K$.
+
+## 2024-06-18 - [Avoid Turf.js Object Allocation in Distance Calculations]
+**Learning:** Computing map distances in hot paths or large iteration loops using `turf.length(turf.lineString(coords))` creates massive garbage collection pressure and CPU overhead because it repeatedly allocates GeoJSON objects and parses them internally.
+**Action:** Replace `turf.length` with the specialized utility `calcPolylineDist(coords)` in `src/core/tripCalculator.js` which performs an $O(N)$ iteration over the coordinate array using `calcDist` without creating intermediate objects.

--- a/src/core/tripCalculator.js
+++ b/src/core/tripCalculator.js
@@ -3,7 +3,7 @@ import { computeLoopVia } from './railwayRouting';
 
 // 辅助：计算两点间直线距离 (Haversine Formula)
 export const calcDist = (lat1, lon1, lat2, lon2) => {
-  if (!lat1 || !lon1 || !lat2 || !lon2) return 0;
+  if (lat1 == null || lon1 == null || lat2 == null || lon2 == null) return 0;
   const R = 6371; // 地球半径 km
   const dLat = (lat2 - lat1) * Math.PI / 180;
   const dLon = (lon2 - lon1) * Math.PI / 180;
@@ -11,6 +11,18 @@ export const calcDist = (lat1, lon1, lat2, lon2) => {
             Math.cos(lat1 * Math.PI / 180) * Math.cos(lat2 * Math.PI / 180) * Math.sin(dLon / 2) * Math.sin(dLon / 2);
   const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
   return R * c;
+};
+
+// 辅助：计算折线段总长度 (基于 calcDist, 避免大量内存分配和循环内转换)
+export const calcPolylineDist = (coords) => {
+  if (!coords || coords.length < 2) return 0;
+  let dist = 0;
+  for (let i = 0; i < coords.length - 1; i++) {
+    const p1 = coords[i];
+    const p2 = coords[i + 1];
+    dist += calcDist(p1[0], p1[1], p2[0], p2[1]);
+  }
+  return dist;
 };
 
 // [New] 路径缝合算法: 将乱序的 MultiLineString 缝合成连续的 LineString
@@ -216,11 +228,11 @@ export const getRouteVisualData = (segments, segmentGeometries, railwayData, geo
             if (geom.isMulti) {
                 geom.coords.forEach(c => {
                     allCoords.push({ coords: c, color: geom.color || '#94a3b8' });
-                    if(turf) totalDist += turf.length(turf.lineString(c.map(p => [p[1], p[0]])));
+                    totalDist += calcPolylineDist(c);
                 });
             } else {
                 allCoords.push({ coords: geom.coords, color: geom.color || '#94a3b8' });
-                if(turf) totalDist += turf.length(turf.lineString(geom.coords.map(p => [p[1], p[0]])));
+                totalDist += calcPolylineDist(geom.coords);
             }
         } else {
              // Fallback Distance Approx

--- a/src/pages/StatsPage.tsx
+++ b/src/pages/StatsPage.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { Github, Folder, TrendingUp, Move, MapPin, Map as MapIcon, Globe } from 'lucide-react';
 import { useStore } from '../store';
-import { calcDist } from '../core/tripCalculator';
+import { calcDist, calcPolylineDist } from '../core/tripCalculator';
 import * as turf from '@turf/turf';
 import { useShallow } from 'zustand/react/shallow';
 import { useUserData } from '../hooks/useUserData';
@@ -77,10 +77,10 @@ export const StatsPage: React.FC = () => {
                         if (geom.isMulti) {
                             for (let k = 0; k < geom.coords.length; k++) {
                                 const c = geom.coords[k];
-                                _totalDist += turf.length(turf.lineString(c.map((p: any) => [p[1], p[0]])));
+                                _totalDist += calcPolylineDist(c);
                             }
                         } else {
-                            _totalDist += turf.length(turf.lineString(geom.coords.map((p: any) => [p[1], p[0]])));
+                            _totalDist += calcPolylineDist(geom.coords);
                         }
                     } else {
                         const line = railwayData[seg.lineKey];


### PR DESCRIPTION
💡 **What**:
- Modified `calcDist` in `src/core/tripCalculator.js` to correctly handle `0` coordinate values by replacing falsy checks (`!lat1`) with explicit nullish checks (`lat1 == null`).
- Created a new helper `calcPolylineDist(coords)` in `src/core/tripCalculator.js` that iterates over a coordinate array and uses `calcDist` directly.
- Replaced multiple occurrences of `turf.length(turf.lineString(c.map(...)))` with `calcPolylineDist(c)` in `src/core/tripCalculator.js` and `src/pages/StatsPage.tsx`.

🎯 **Why**:
- Using `turf.length` required wrapping coordinates in `turf.lineString`, allocating new GeoJSON objects and performing deep parsing in every iteration.
- Because `turf` requires `[lng, lat]` format and the app uses `[lat, lng]`, each point was being `.map()`ped into a new array. This generated massive temporary garbage collection pressure and CPU overhead in hot rendering loops, especially on the Stats page which processes full trip histories.

📊 **Impact**:
- Reduces memory allocations and significantly cuts down CPU execution time when parsing map route visuals and stats calculations by using a fast $O(N)$ iteration instead of allocating/mapping intermediate objects.

🔬 **Measurement**:
- UI verification script run via Playwright successfully confirming the application still loads the `StatsPage` distance visualizations correctly.
- `tsc` and `vite build` completed successfully without logic errors.

---
*PR created automatically by Jules for task [10144292300633385815](https://jules.google.com/task/10144292300633385815) started by @OsakaLOOP*