### PR TITLE
⚡ Bolt: Replace turf.length with O(N) calcPolylineDist to prevent temporary object allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-04-15 - [Avoid O(N log N) Sorting on Massive Geographical Collections]
 **Learning:** In spatial queries like `findNearbyStations` where we scan `railwayData` containing thousands of stations to find the top K nearest points, allocating all elements to an array and running `Array.prototype.sort()` results in massive temporary object allocation and $O(N \log N)$ execution time (taking ~8.5ms in benchmarks).
 **Action:** Replace full array sorts with a bounded Top-K array using a simple $O(K)$ insertion sort during the $O(N)$ iteration phase. This brings the time complexity effectively down to $O(N)$, speeding up operations by ~36x (taking ~0.24ms). Remember to apply a final sort if total elements found are less than $K$.
+
+## 2024-06-20 - [Avoid Turf.js Object Allocation in Loops]
+**Learning:** Using `turf.length(turf.lineString(coords.map(...)))` inside loops (like path geometry mapping) leads to significant performance issues due to continuous heavy intermediate object allocations (array maps, GeoJSON creation) which triggers frequent GC sweeps and degrades performance especially when analyzing large path datasets over the UI's `useMemo` loops.
+**Action:** Replace `turf.length` with a direct O(N) traversal distance computation, `calcPolylineDist(coords)`, taking advantage of the `calcDist` (Haversine Formula). This avoids massive memory overhead.

--- a/src/core/tripCalculator.js
+++ b/src/core/tripCalculator.js
@@ -13,6 +13,18 @@ export const calcDist = (lat1, lon1, lat2, lon2) => {
   return R * c;
 };
 
+// 辅助：计算一系列坐标点组成的多边形路径长度 (O(N) 遍历)
+export const calcPolylineDist = (coords) => {
+  if (!coords || coords.length < 2) return 0;
+  let totalDist = 0;
+  for (let i = 0; i < coords.length - 1; i++) {
+    const p1 = coords[i];
+    const p2 = coords[i + 1];
+    totalDist += calcDist(p1[0], p1[1], p2[0], p2[1]);
+  }
+  return totalDist;
+};
+
 // [New] 路径缝合算法: 将乱序的 MultiLineString 缝合成连续的 LineString
 export const stitchRoutes = (turf, multiCoords, startPt) => {
   let pool = multiCoords.map((coords, i) => {
@@ -216,11 +228,11 @@ export const getRouteVisualData = (segments, segmentGeometries, railwayData, geo
             if (geom.isMulti) {
                 geom.coords.forEach(c => {
                     allCoords.push({ coords: c, color: geom.color || '#94a3b8' });
-                    if(turf) totalDist += turf.length(turf.lineString(c.map(p => [p[1], p[0]])));
+                    totalDist += calcPolylineDist(c);
                 });
             } else {
                 allCoords.push({ coords: geom.coords, color: geom.color || '#94a3b8' });
-                if(turf) totalDist += turf.length(turf.lineString(geom.coords.map(p => [p[1], p[0]])));
+                totalDist += calcPolylineDist(geom.coords);
             }
         } else {
              // Fallback Distance Approx

--- a/src/pages/StatsPage.tsx
+++ b/src/pages/StatsPage.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { Github, Folder, TrendingUp, Move, MapPin, Map as MapIcon, Globe } from 'lucide-react';
 import { useStore } from '../store';
-import { calcDist } from '../core/tripCalculator';
+import { calcDist, calcPolylineDist } from '../core/tripCalculator';
 import * as turf from '@turf/turf';
 import { useShallow } from 'zustand/react/shallow';
 import { useUserData } from '../hooks/useUserData';
@@ -77,10 +77,10 @@ export const StatsPage: React.FC = () => {
                         if (geom.isMulti) {
                             for (let k = 0; k < geom.coords.length; k++) {
                                 const c = geom.coords[k];
-                                _totalDist += turf.length(turf.lineString(c.map((p: any) => [p[1], p[0]])));
+                                _totalDist += calcPolylineDist(c);
                             }
                         } else {
-                            _totalDist += turf.length(turf.lineString(geom.coords.map((p: any) => [p[1], p[0]])));
+                            _totalDist += calcPolylineDist(geom.coords);
                         }
                     } else {
                         const line = railwayData[seg.lineKey];


### PR DESCRIPTION
💡 What: Implemented `calcPolylineDist(coords)` in `src/core/tripCalculator.js` to replace usages of `turf.length(turf.lineString(...))` mapped over large arrays in loops.
🎯 Why: `turf.length` with `coords.map` forces the browser to heavily allocate temporary `Array` loops and Turf-specific GeoJSON wrapper objects continuously across UI recalculations in hooks like `useMemo` (e.g., in `StatsPage.tsx`). This causes measurable UI lag and forces massive GC pressure.
📊 Impact: Considerably reduces garbage collection cycles and CPU load by transforming spatial calculations from allocating new spatial geometry objects into a direct pointer-based mathematical $O(N)$ traversal over the arrays without building wrappers.
🔬 Measurement: Open the Stats view or perform UI state modifications on heavily populated map sets. Observe memory allocation profiles and frame-timing in DevTools to confirm memory and CPU usage reduction versus previous GC sweeps during map redraws or distance aggregations.

---
*PR created automatically by Jules for task [6026625374027812364](https://jules.google.com/task/6026625374027812364) started by @OsakaLOOP*