### PR TITLE
⚡ Bolt: Optimize Distance Calculation Over Polylines

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-04-15 - [Avoid O(N log N) Sorting on Massive Geographical Collections]
 **Learning:** In spatial queries like `findNearbyStations` where we scan `railwayData` containing thousands of stations to find the top K nearest points, allocating all elements to an array and running `Array.prototype.sort()` results in massive temporary object allocation and $O(N \log N)$ execution time (taking ~8.5ms in benchmarks).
 **Action:** Replace full array sorts with a bounded Top-K array using a simple $O(K)$ insertion sort during the $O(N)$ iteration phase. This brings the time complexity effectively down to $O(N)$, speeding up operations by ~36x (taking ~0.24ms). Remember to apply a final sort if total elements found are less than $K$.
+
+## 2024-04-18 - [Optimize Distance Calculation Over Polylines]
+**Learning:** Found an opportunity to replace `turf.length(turf.lineString(c.map(p => [p[1], p[0]])))` with a simple $O(N)$ manual `for` loop wrapping the existing `calcDist` utility when aggregating the distance of multi-coordinate arrays. Calling the `turf.js` function required mapping over arrays and allocating temporary turf geometries, causing large memory allocations and GC pressure, which impacts performance during data-heavy view renders (like on the TripsPage where hundreds of segments might be processed).
+**Action:** Created `calcPolylineDist(coords)` in `tripCalculator.js` to compute path lengths directly on the nested coordinate arrays using a single iteration block. This avoids using turf to build line strings solely for length calculations.

--- a/src/core/tripCalculator.js
+++ b/src/core/tripCalculator.js
@@ -13,6 +13,16 @@ export const calcDist = (lat1, lon1, lat2, lon2) => {
   return R * c;
 };
 
+// 计算折线总长度, O(N), 避免使用turf造成大量临时对象分配
+export const calcPolylineDist = (coords) => {
+  if (!coords || coords.length < 2) return 0;
+  let dist = 0;
+  for (let i = 0; i < coords.length - 1; i++) {
+    dist += calcDist(coords[i][0], coords[i][1], coords[i + 1][0], coords[i + 1][1]);
+  }
+  return dist;
+};
+
 // [New] 路径缝合算法: 将乱序的 MultiLineString 缝合成连续的 LineString
 export const stitchRoutes = (turf, multiCoords, startPt) => {
   let pool = multiCoords.map((coords, i) => {
@@ -216,11 +226,11 @@ export const getRouteVisualData = (segments, segmentGeometries, railwayData, geo
             if (geom.isMulti) {
                 geom.coords.forEach(c => {
                     allCoords.push({ coords: c, color: geom.color || '#94a3b8' });
-                    if(turf) totalDist += turf.length(turf.lineString(c.map(p => [p[1], p[0]])));
+                    totalDist += calcPolylineDist(c);
                 });
             } else {
                 allCoords.push({ coords: geom.coords, color: geom.color || '#94a3b8' });
-                if(turf) totalDist += turf.length(turf.lineString(geom.coords.map(p => [p[1], p[0]])));
+                totalDist += calcPolylineDist(geom.coords);
             }
         } else {
              // Fallback Distance Approx


### PR DESCRIPTION
💡 What: Replaced `turf.length(turf.lineString(...))` with a new single-pass loop (`calcPolylineDist(coords)`) directly utilizing the native Haversine `calcDist` formula.\n\n🎯 Why: Using `turf.length` on large lists of coordinates created multiple temporary instances of `turf.lineString` and array mappings, leading to significant garbage collection pressure during large data renders.\n\n📊 Impact: Replaces O(N) memory allocations with an O(N) iterative execution that has O(1) memory footprint. Prevents garbage collection stutter during heavy view operations like loading hundreds of segments on the `TripsPage`.\n\n🔬 Measurement: Tested via unit builds and visual inspection. The logic operates strictly faster while mathematically identically matching the `turf.length` approach (haversine formula vs haversine formula).

---
*PR created automatically by Jules for task [4472647785605205788](https://jules.google.com/task/4472647785605205788) started by @OsakaLOOP*