### PR TITLE
⚡ Bolt: optimize polyline distance calculations by removing Turf.js allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-04-15 - [Avoid O(N log N) Sorting on Massive Geographical Collections]
 **Learning:** In spatial queries like `findNearbyStations` where we scan `railwayData` containing thousands of stations to find the top K nearest points, allocating all elements to an array and running `Array.prototype.sort()` results in massive temporary object allocation and $O(N \log N)$ execution time (taking ~8.5ms in benchmarks).
 **Action:** Replace full array sorts with a bounded Top-K array using a simple $O(K)$ insertion sort during the $O(N)$ iteration phase. This brings the time complexity effectively down to $O(N)$, speeding up operations by ~36x (taking ~0.24ms). Remember to apply a final sort if total elements found are less than $K$.
+
+## 2024-06-24 - [Avoid `turf.length(turf.lineString(...))` for Distance Calculations]
+**Learning:** Using `turf.length(turf.lineString(coords))` over thousands of coordinate pairs creates massive GC overhead and slows down presentation-layer aggregation because it allocates temporary `turf.lineString` objects repeatedly just to calculate the physical line length.
+**Action:** Use an O(N) explicit polyline distance accumulator loop like `calcPolylineDist(coords)` combining manual native `calcDist` iterations between sequential points instead of `turf.length` wrappers to bypass memory allocations and dramatically improve performance.

--- a/src/core/tripCalculator.js
+++ b/src/core/tripCalculator.js
@@ -3,7 +3,7 @@ import { computeLoopVia } from './railwayRouting';
 
 // 辅助：计算两点间直线距离 (Haversine Formula)
 export const calcDist = (lat1, lon1, lat2, lon2) => {
-  if (!lat1 || !lon1 || !lat2 || !lon2) return 0;
+  if (lat1 == null || lon1 == null || lat2 == null || lon2 == null) return 0;
   const R = 6371; // 地球半径 km
   const dLat = (lat2 - lat1) * Math.PI / 180;
   const dLon = (lon2 - lon1) * Math.PI / 180;
@@ -157,6 +157,16 @@ export const sliceGeoJsonPath = (feature, startLat, startLng, endLat, endLng) =>
     }
 };
 
+export const calcPolylineDist = (coords) => {
+  let dist = 0;
+  for (let i = 0; i < coords.length - 1; i++) {
+    const p1 = coords[i];
+    const p2 = coords[i + 1];
+    dist += calcDist(p1[0], p1[1], p2[0], p2[1]);
+  }
+  return dist;
+};
+
 // --- Shared Helper: Calculate Visualization Data ---
 export const getRouteVisualData = (segments, segmentGeometries, railwayData, geoData) => {
     let totalDist = 0;
@@ -216,11 +226,11 @@ export const getRouteVisualData = (segments, segmentGeometries, railwayData, geo
             if (geom.isMulti) {
                 geom.coords.forEach(c => {
                     allCoords.push({ coords: c, color: geom.color || '#94a3b8' });
-                    if(turf) totalDist += turf.length(turf.lineString(c.map(p => [p[1], p[0]])));
+                    totalDist += calcPolylineDist(c);
                 });
             } else {
                 allCoords.push({ coords: geom.coords, color: geom.color || '#94a3b8' });
-                if(turf) totalDist += turf.length(turf.lineString(geom.coords.map(p => [p[1], p[0]])));
+                totalDist += calcPolylineDist(geom.coords);
             }
         } else {
              // Fallback Distance Approx

--- a/src/pages/StatsPage.tsx
+++ b/src/pages/StatsPage.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { Github, Folder, TrendingUp, Move, MapPin, Map as MapIcon, Globe } from 'lucide-react';
 import { useStore } from '../store';
-import { calcDist } from '../core/tripCalculator';
+import { calcDist, calcPolylineDist } from '../core/tripCalculator';
 import * as turf from '@turf/turf';
 import { useShallow } from 'zustand/react/shallow';
 import { useUserData } from '../hooks/useUserData';
@@ -77,10 +77,10 @@ export const StatsPage: React.FC = () => {
                         if (geom.isMulti) {
                             for (let k = 0; k < geom.coords.length; k++) {
                                 const c = geom.coords[k];
-                                _totalDist += turf.length(turf.lineString(c.map((p: any) => [p[1], p[0]])));
+                                _totalDist += calcPolylineDist(c);
                             }
                         } else {
-                            _totalDist += turf.length(turf.lineString(geom.coords.map((p: any) => [p[1], p[0]])));
+                            _totalDist += calcPolylineDist(geom.coords);
                         }
                     } else {
                         const line = railwayData[seg.lineKey];


### PR DESCRIPTION
### 💡 What: 
- Replaced multiple occurrences of `turf.length(turf.lineString(...))` mapped over coordinate arrays with an explicit loop `calcPolylineDist(coords)`.
- Updated `calcDist` to use explicit nullish checks instead of truthy checks (fixing a potential bug where coordinates falling on the equator/prime meridian evaluate to falsy and bypass distance calculation).

### 🎯 Why: 
Calling `turf.length` constructs intermediate temporary GeoJSON object allocations per segment which creates significant garbage collection overhead and negatively affects execution time on a massive array iteration scale. 

### 📊 Impact: 
Significantly reduces transient object instantiation and GC pressure when calculating route/segment geometries in the presentation layer (`StatsPage` and `tripCalculator.js`), boosting loop performance by bypassing heavy wrapper library calls.

### 🔬 Measurement:
- Run application and verify StatsPage metrics are correct.
- Added a journal entry to `.jules/bolt.md` for this O(N) allocation avoidance pattern.

---
*PR created automatically by Jules for task [10664529139223050309](https://jules.google.com/task/10664529139223050309) started by @OsakaLOOP*